### PR TITLE
Lambdaexpr

### DIFF
--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -36,6 +36,7 @@ from astx.callables import (
     FunctionCall,
     FunctionPrototype,
     FunctionReturn,
+    LambdaExpr,
 )
 from astx.datatypes import (
     Boolean,
@@ -167,6 +168,7 @@ __all__ = [
     "UInt32",
     "UInt64",
     "UInt128",
+    "LambdaExpr",
     "Literal",
     "LiteralBoolean",
     "LiteralInt8",

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -128,6 +128,8 @@ class ASTKind(Enum):
     ImportExprKind = -800
     ImportFromExprKind = -801
 
+    LambdaExprKind = -807
+
 
 class ASTMeta(type):
     def __str__(cls) -> str:

--- a/src/astx/callables.py
+++ b/src/astx/callables.py
@@ -252,3 +252,36 @@ class Function(StatementType):
 
         value: ReprStruct = {**args_struct, **body_struct}
         return self._prepare_struct(key, value, simplified)
+
+
+@public
+class LambdaExpr(Expr):
+    """AST class for lambda expressions."""
+
+    params: Arguments
+    body: Expr
+
+    def __init__(
+        self,
+        params: Arguments,
+        body: Expr,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        super().__init__(loc=loc, parent=parent)
+        self.params = params
+        self.body = body
+        self.kind = ASTKind.LambdaExprKind
+
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        return f" lambda x: {self.body}"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the import-from expression."""
+        body = self.body
+        # body_str = body.get_struct(simplified)
+        key = "LambdaExpr"
+
+        value = cast(ReprStruct, body.get_struct(simplified))
+        return self._prepare_struct(key, value, simplified)

--- a/src/astx/transpilers/python.py
+++ b/src/astx/transpilers/python.py
@@ -179,6 +179,11 @@ class ASTxPythonTranspiler:
         return f"return {value}"
 
     @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.LambdaExpr) -> str:
+        """Handle LambdaExpr nodes."""
+        return f" lambda x: {self.visit(node.body)}"
+
+    @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.UnaryOp) -> str:
         """Handle UnaryOp nodes."""
         operand = self.visit(node.operand)

--- a/src/astx/transpilers/python.py
+++ b/src/astx/transpilers/python.py
@@ -181,7 +181,7 @@ class ASTxPythonTranspiler:
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.LambdaExpr) -> str:
         """Handle LambdaExpr nodes."""
-        return f" lambda x: {self.visit(node.body)}"
+        return f"lambda x: {self.visit(node.body)}"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.UnaryOp) -> str:

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -10,9 +10,12 @@ from astx.callables import (
     FunctionCall,
     FunctionPrototype,
     FunctionReturn,
+    LambdaExpr,
 )
 from astx.datatypes import Int32, LiteralInt32
 from astx.modifiers import ScopeKind, VisibilityKind
+from astx.operators import BinaryOp
+from astx.variables import Variable
 from astx.viz import visualize
 
 
@@ -91,3 +94,14 @@ def test_function_return() -> None:
     assert str(fn_return)
     assert fn_return.get_struct()
     assert fn_return.get_struct(simplified=True)
+
+
+def test_lambdaexpr() -> None:
+    """Test the LambdaExpr class."""
+    params = Arguments(Argument(name="a", type_=Int32))
+    body = BinaryOp(op_code="+", lhs=Variable(name="x"), rhs=LiteralInt32(1))
+    lambda_expr = LambdaExpr(params=params, body=body)
+
+    assert str(lambda_expr)
+    assert lambda_expr.get_struct()
+    assert lambda_expr.get_struct(simplified=True)

--- a/tests/transpilers/test_python.py
+++ b/tests/transpilers/test_python.py
@@ -186,6 +186,26 @@ def test_transpiler_relative_import_from_expr() -> None:
     assert generated_code == expected_code, "generated_code != expected_code"
 
 
+def test_transpiler_lambdaexpr() -> None:
+    """Test astx.LambdaExpr."""
+    params = astx.Arguments(astx.Argument(name="a", type_=astx.Int32))
+    body = astx.BinaryOp(
+        op_code="+", lhs=astx.Variable(name="x"), rhs=astx.LiteralInt32(1)
+    )
+
+    lambda_expr = astx.LambdaExpr(params=params, body=body)
+
+    # Initialize the generator
+    generator = astx2py.ASTxPythonTranspiler()
+
+    # Generate Python code
+    generated_code = generator.visit(lambda_expr)
+
+    expected_code = "lambda x: (x + 1)"
+
+    assert generated_code == expected_code, "generated_code != expected_code"
+
+
 def test_transpiler_function() -> None:
     """Test astx.Function."""
     # Function parameters


### PR DESCRIPTION
## Pull Request description

This PR adds LambdaExpr class.
This PR is an attempt to solve https://github.com/arxlang/astx/issues/104 .

added new ASTKind's
created LambdaExpr classes
updated __init__.py to include the new imports and classes in the __all__ list
added the new class visit method in transpilers/python.py
added tests in tests/transpilers/test_python.py
added tests in tests/test_packages.py

## How to test these changes
```python
from astx.callables import Argument, Arguments, LambdaExpr
from astx.datatypes import LiteralInt32, Int32
from astx.operators import BinaryOp
from astx.variables import Variable

from astx.transpilers import python as astx2py

# Create parameters and body for the lambda
params = Arguments(Argument(name="a", type_=Int32))
body = BinaryOp(op_code="+", lhs=Variable(name="x"), rhs=LiteralInt32(1))

# Create the LambdaExpr
lambda_expr = LambdaExpr(params=params, body=body)

lambda_expr.get_struct()
lambda_expr.get_struct(simplified=True)
lambda_expr.__str__()

generator = astx2py.ASTxPythonTranspiler()
generated_code = generator.visit(lambda_expr)
print(generated_code) 
```

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [X] new feature
- [ ] maintenance

About this PR:

- [X] it includes tests.
- [X] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [X] I have reviewed the changes and it contains no misspelling.
- [X] The code is well commented, especially in the parts that contain more
      complexity.
- [X] New and old tests passed locally.

## Additional information

![lambdaexprAST](https://github.com/user-attachments/assets/7221586a-c744-48be-90fc-34f061868577)

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
