### PR TITLE
fix: change args type in `FunctionCall` class

### DIFF
--- a/src/astx/callables.py
+++ b/src/astx/callables.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, cast
+from typing import Any, Iterable, Optional, cast
 
 from public import public
 from typeguard import typechecked
@@ -96,12 +96,12 @@ class FunctionCall(DataType):
     """AST class for function call."""
 
     fn: Function
-    args: tuple[DataType, ...]
+    args: Iterable[DataType]
 
     def __init__(
         self,
         fn: Function,
-        args: tuple[DataType, ...],
+        args: Iterable[DataType],
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
     ) -> None:


### PR DESCRIPTION
## Pull Request description

Changed the data type of args to Iterable in `FunctionCall` class. This is an attempt to solve #138 .
With this modification, the [Fibonacci tutorial](https://astx.arxlang.org/tutorials/fibonacci/) should run with no problems.

## Pull Request checklists

This PR is a:

- [X] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
