### PR TITLE
feat: add ForCountLoopExpr class

### DIFF
--- a/docs/tutorials/for-loop.ipynb
+++ b/docs/tutorials/for-loop.ipynb
@@ -148,7 +148,7 @@
     "body_for = astx.Block()\n",
     "\n",
     "# Define a For Count Loop\n",
-    "for_counter = astx.ForCountLoop(\n",
+    "for_counter = astx.ForCountLoopStmt(\n",
     "    initializer=decl_a,\n",
     "    condition=var_a < astx.LiteralInt32(10),\n",
     "    update=astx.UnaryOp(\"++\", var_a),\n",
@@ -161,7 +161,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "astx",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -175,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -85,7 +85,7 @@ from astx.datatypes import (
     UTF8String,
 )
 from astx.flows import (
-    ForCountLoop,
+    ForCountLoopStmt,
     ForRangeLoopExpr,
     ForRangeLoopStmt,
     If,
@@ -158,7 +158,7 @@ __all__ = [
     "LiteralFloat64",
     "Floating",
     "flows",
-    "ForCountLoop",
+    "ForCountLoopStmt",
     "ForRangeLoopStmt",
     "ForRangeLoopExpr",
     "Function",

--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -85,6 +85,7 @@ from astx.datatypes import (
     UTF8String,
 )
 from astx.flows import (
+    ForCountLoopExpr,
     ForCountLoopStmt,
     ForRangeLoopExpr,
     ForRangeLoopStmt,
@@ -159,6 +160,7 @@ __all__ = [
     "Floating",
     "flows",
     "ForCountLoopStmt",
+    "ForCountLoopExpr",
     "ForRangeLoopStmt",
     "ForRangeLoopExpr",
     "Function",

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -97,7 +97,7 @@ class ASTKind(Enum):
 
     # control flow
     IfKind = -500
-    ForCountKind = -501
+    ForCountLoopStmtKind = -501
     ForRangeLoopStmtKind = -502
     WhileKind = -503
     ForRangeLoopExprKind = -504

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -101,7 +101,7 @@ class ASTKind(Enum):
     ForRangeLoopStmtKind = -502
     WhileKind = -503
     ForRangeLoopExprKind = -504
-    ForCountLoopExprKind = -501
+    ForCountLoopExprKind = -505
 
     # data types
     NullDTKind = -600

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -101,6 +101,7 @@ class ASTKind(Enum):
     ForRangeLoopStmtKind = -502
     WhileKind = -503
     ForRangeLoopExprKind = -504
+    ForCountLoopExprKind = -501
 
     # data types
     NullDTKind = -600

--- a/src/astx/flows.py
+++ b/src/astx/flows.py
@@ -185,7 +185,7 @@ class ForRangeLoopExpr(Expr):
 
 @public
 @typechecked
-class ForCountLoop(StatementType):
+class ForCountLoopStmt(StatementType):
     """
     AST class for a simple Count-Controlled `For` Loop statement.
 
@@ -212,7 +212,7 @@ class ForCountLoop(StatementType):
         self.condition = condition
         self.update = update
         self.body = body
-        self.kind = ASTKind.ForCountKind
+        self.kind = ASTKind.ForCountLoopStmtKind
 
     def __str__(self) -> str:
         """Return a string that represents the object."""

--- a/src/astx/flows.py
+++ b/src/astx/flows.py
@@ -241,6 +241,61 @@ class ForCountLoopStmt(StatementType):
 
 @public
 @typechecked
+class ForCountLoopExpr(Expr):
+    """
+    AST class for a simple Count-Controlled `For` Loop expression.
+
+    This is a very basic `for` loop, used by languages like C or C++.
+    """
+
+    initializer: InlineVariableDeclaration
+    condition: Expr
+    update: Expr
+    body: Block
+
+    def __init__(
+        self,
+        initializer: InlineVariableDeclaration,
+        condition: Expr,
+        update: Expr,
+        body: Block,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the ForStmt instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.initializer = initializer
+        self.condition = condition
+        self.update = update
+        self.body = body
+        self.kind = ASTKind.ForCountLoopExprKind
+
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        init = self.initializer
+        cond = self.condition
+        update = self.update
+        return f"ForCountLoop({init};{cond};{update})"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        for_init = {"initialization": self.initializer.get_struct(simplified)}
+        for_cond = {"condition": self.condition.get_struct(simplified)}
+        for_update = {"update": self.update.get_struct(simplified)}
+        for_body = self.body.get_struct(simplified)
+
+        key = "FOR-COUNT-STMT"
+        value: ReprStruct = {
+            **cast(DictDataTypesStruct, for_init),
+            **cast(DictDataTypesStruct, for_cond),
+            **cast(DictDataTypesStruct, for_update),
+            **cast(DictDataTypesStruct, for_body),
+        }
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
 class While(StatementType):
     """AST class for `while` statement."""
 

--- a/src/astx/flows.py
+++ b/src/astx/flows.py
@@ -206,7 +206,7 @@ class ForCountLoopStmt(StatementType):
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
     ) -> None:
-        """Initialize the ForStmt instance."""
+        """Initialize the ForCountLoopStmt instance."""
         super().__init__(loc=loc, parent=parent)
         self.initializer = initializer
         self.condition = condition
@@ -219,7 +219,7 @@ class ForCountLoopStmt(StatementType):
         init = self.initializer
         cond = self.condition
         update = self.update
-        return f"ForCountLoop({init};{cond};{update})"
+        return f"ForCountLoopStmt({init};{cond};{update})"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
@@ -262,7 +262,7 @@ class ForCountLoopExpr(Expr):
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
     ) -> None:
-        """Initialize the ForStmt instance."""
+        """Initialize the ForLoopCountExpr instance."""
         super().__init__(loc=loc, parent=parent)
         self.initializer = initializer
         self.condition = condition
@@ -275,7 +275,7 @@ class ForCountLoopExpr(Expr):
         init = self.initializer
         cond = self.condition
         update = self.update
-        return f"ForCountLoop({init};{cond};{update})"
+        return f"ForCountLoopExpr({init};{cond};{update})"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
@@ -284,7 +284,7 @@ class ForCountLoopExpr(Expr):
         for_update = {"update": self.update.get_struct(simplified)}
         for_body = self.body.get_struct(simplified)
 
-        key = "FOR-COUNT-STMT"
+        key = "FOR-COUNT-EXPR"
         value: ReprStruct = {
             **cast(DictDataTypesStruct, for_init),
             **cast(DictDataTypesStruct, for_cond),

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -98,7 +98,7 @@ def test_for_count_loop_stmt() -> None:
 
 
 def test_for_count_loop_expr() -> None:
-    """Test `For Count Loop` statement."""
+    """Test `For Count Loop` expression."""
     decl_a = InlineVariableDeclaration("a", type_=Int32, value=LiteralInt32(0))
     var_a = Variable("a")
     cond = BinaryOp(op_code="<", lhs=var_a, rhs=LiteralInt32(10))

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2,7 +2,13 @@
 
 from astx.blocks import Block
 from astx.datatypes import Int32, LiteralInt32
-from astx.flows import ForCountLoopStmt, ForRangeLoopExpr, ForRangeLoopStmt, If
+from astx.flows import (
+    ForCountLoopExpr,
+    ForCountLoopStmt,
+    ForRangeLoopExpr,
+    ForRangeLoopStmt,
+    If,
+)
 from astx.operators import BinaryOp, UnaryOp
 from astx.variables import InlineVariableDeclaration, Variable
 from astx.viz import visualize
@@ -73,7 +79,7 @@ def test_for_range_loop_stmt() -> None:
     visualize(for_stmt.get_struct())
 
 
-def test_for_count() -> None:
+def test_for_count_loop_stmt() -> None:
     """Test `For Count Loop` statement."""
     decl_a = InlineVariableDeclaration("a", type_=Int32, value=LiteralInt32(0))
     var_a = Variable("a")
@@ -89,3 +95,21 @@ def test_for_count() -> None:
     assert for_stmt.get_struct()
     assert for_stmt.get_struct(simplified=True)
     visualize(for_stmt.get_struct())
+
+
+def test_for_count_loop_expr() -> None:
+    """Test `For Count Loop` statement."""
+    decl_a = InlineVariableDeclaration("a", type_=Int32, value=LiteralInt32(0))
+    var_a = Variable("a")
+    cond = BinaryOp(op_code="<", lhs=var_a, rhs=LiteralInt32(10))
+    update = UnaryOp(op_code="++", operand=var_a)
+    body = Block()
+    body.append(LiteralInt32(2))
+    for_expr = ForCountLoopExpr(
+        initializer=decl_a, condition=cond, update=update, body=body
+    )
+
+    assert str(for_expr)
+    assert for_expr.get_struct()
+    assert for_expr.get_struct(simplified=True)
+    visualize(for_expr.get_struct())

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -2,7 +2,7 @@
 
 from astx.blocks import Block
 from astx.datatypes import Int32, LiteralInt32
-from astx.flows import ForCountLoop, ForRangeLoopExpr, ForRangeLoopStmt, If
+from astx.flows import ForCountLoopStmt, ForRangeLoopExpr, ForRangeLoopStmt, If
 from astx.operators import BinaryOp, UnaryOp
 from astx.variables import InlineVariableDeclaration, Variable
 from astx.viz import visualize
@@ -81,7 +81,7 @@ def test_for_count() -> None:
     update = UnaryOp(op_code="++", operand=var_a)
     body = Block()
     body.append(LiteralInt32(2))
-    for_stmt = ForCountLoop(
+    for_stmt = ForCountLoopStmt(
         initializer=decl_a, condition=cond, update=update, body=body
     )
 


### PR DESCRIPTION
## Pull Request description

This PR adds the `ForCountLoopExpr` class. This is an attempt to solve #95 .

## How to test these changes

```python
from astx.blocks import Block
from astx.datatypes import Int32, LiteralInt32
from astx.flows import ForCountLoopExpr
from astx.operators import BinaryOp, UnaryOp
from astx.variables import InlineVariableDeclaration, Variable

decl_a = InlineVariableDeclaration("a", type_=Int32, value=LiteralInt32(0))
var_a = Variable("a")
cond = BinaryOp(op_code="<", lhs=var_a, rhs=LiteralInt32(10))
update = UnaryOp(op_code="++", operand=var_a)
body = Block()
body.append(LiteralInt32(2))
for_expr = ForCountLoopExpr(
initializer=decl_a, condition=cond, update=update, body=body)
for_expr
```
![for_count_expr](https://github.com/user-attachments/assets/fb9e99bd-ef46-41ae-8053-fda072247a78)

![for_count_expr_png](https://github.com/user-attachments/assets/1b21d6f1-cee8-4355-afee-6e0853069437)


## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [X] new feature
- [ ] maintenance

About this PR:

- [X] it includes tests.
- [X] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [X] I have reviewed the changes and it contains no misspelling.
- [X] The code is well commented, especially in the parts that contain more
      complexity.
- [X] New and old tests passed locally.

## Additional information

Note that there is no transpiler visit method for this class, just like for `ForCountLoopStmt`.

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
