### PR TITLE
feat: create WhileExpr class

### DIFF
--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -90,7 +90,8 @@ from astx.flows import (
     ForRangeLoopExpr,
     ForRangeLoopStmt,
     If,
-    While,
+    WhileExpr,
+    WhileStmt,
 )
 from astx.mixes import (
     NamedExpr,
@@ -222,7 +223,8 @@ __all__ = [
     "Variable",
     "variables",
     "VisibilityKind",
-    "While",
+    "WhileStmt",
+    "WhileExpr",
     "Complex",
     "Complex32",
     "Complex64",

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -99,9 +99,10 @@ class ASTKind(Enum):
     IfKind = -500
     ForCountLoopStmtKind = -501
     ForRangeLoopStmtKind = -502
-    WhileKind = -503
+    WhileStmtKind = -503
     ForRangeLoopExprKind = -504
     ForCountLoopExprKind = -505
+    WhileExprKind = -506
 
     # data types
     NullDTKind = -600

--- a/src/astx/flows.py
+++ b/src/astx/flows.py
@@ -296,7 +296,7 @@ class ForCountLoopExpr(Expr):
 
 @public
 @typechecked
-class While(StatementType):
+class WhileStmt(StatementType):
     """AST class for `while` statement."""
 
     condition: Expr
@@ -309,15 +309,15 @@ class While(StatementType):
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
     ) -> None:
-        """Initialize the While instance."""
+        """Initialize the WhileStmt instance."""
         super().__init__(loc=loc, parent=parent)
         self.condition = condition
         self.body = body
-        self.kind = ASTKind.WhileKind
+        self.kind = ASTKind.WhileStmtKind
 
     def __str__(self) -> str:
         """Return a string representation of the object."""
-        return f"While[{self.condition}]"
+        return f"WhileStmt[{self.condition}]"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
@@ -325,6 +325,45 @@ class While(StatementType):
         while_body = self.body.get_struct(simplified)
 
         key = "WHILE-STMT"
+        value: ReprStruct = {
+            **cast(DictDataTypesStruct, while_condition),
+            **cast(DictDataTypesStruct, while_body),
+        }
+
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class WhileExpr(Expr):
+    """AST class for `while` expression."""
+
+    condition: Expr
+    body: Block
+
+    def __init__(
+        self,
+        condition: Expr,
+        body: Block,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the WhileExpr instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.condition = condition
+        self.body = body
+        self.kind = ASTKind.WhileExprKind
+
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        return f"WhileExpr[{self.condition}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        while_condition = self.condition.get_struct(simplified)
+        while_body = self.body.get_struct(simplified)
+
+        key = "WHILE-EXPR"
         value: ReprStruct = {
             **cast(DictDataTypesStruct, while_condition),
             **cast(DictDataTypesStruct, while_body),

--- a/src/astx/transpilers/python.py
+++ b/src/astx/transpilers/python.py
@@ -82,22 +82,47 @@ class ASTxPythonTranspiler:
         )
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.ImportFromStmt) -> str:
-        """Handle ImportFromStmt nodes."""
-        names = [self.visit(name) for name in node.names]
-        level_dots = "." * node.level
-        module_str = (
-            f"{level_dots}{node.module}" if node.module else level_dots
+    def visit(self, node: astx.Function) -> str:
+        """Handle Function nodes."""
+        args = self.visit(node.prototype.args)
+        returns = (
+            f" -> {self.visit(node.prototype.return_type)}"
+            if node.prototype.return_type
+            else ""
         )
-        names_str = ", ".join(str(name) for name in names)
-        return f"from {module_str} import {names_str}"
+        header = f"def {node.name}({args}){returns}:"
+        body = self.visit(node.body)
+        return f"{header}\n{body}"
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.ImportStmt) -> str:
-        """Handle ImportStmt nodes."""
+    def visit(self, node: astx.FunctionReturn) -> str:
+        """Handle FunctionReturn nodes."""
+        value = self.visit(node.value) if node.value else ""
+        return f"return {value}"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.ImportExpr) -> str:
+        """Handle ImportExpr nodes."""
         names = [self.visit(name) for name in node.names]
-        names_str = ", ".join(x for x in names)
-        return f"import {names_str}"
+        names_list = []
+        for name in names:
+            str_ = f"__import__('{name}') "
+            names_list.append(str_)
+        names_str = ", ".join(x for x in names_list)
+
+        # name if one import or name1, name2, etc if multiple imports
+        num = [
+            "" if len(names) == 1 else str(n) for n in range(1, len(names) + 1)
+        ]
+        call = ["module" + str(n) for n in num]
+        call_str = ", ".join(x for x in call)
+
+        # assign tuple if multiple imports
+        names_str = (
+            names_str if len(names_list) == 1 else "(" + names_str + ")"
+        )
+
+        return f"{call_str} = {names_str}"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.ImportFromExpr) -> str:
@@ -131,62 +156,22 @@ class ASTxPythonTranspiler:
         return f"{call_str} = {names_str}"
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.ImportExpr) -> str:
-        """Handle ImportExpr nodes."""
+    def visit(self, node: astx.ImportStmt) -> str:
+        """Handle ImportStmt nodes."""
         names = [self.visit(name) for name in node.names]
-        names_list = []
-        for name in names:
-            str_ = f"__import__('{name}') "
-            names_list.append(str_)
-        names_str = ", ".join(x for x in names_list)
+        names_str = ", ".join(x for x in names)
+        return f"import {names_str}"
 
-        # name if one import or name1, name2, etc if multiple imports
-        num = [
-            "" if len(names) == 1 else str(n) for n in range(1, len(names) + 1)
-        ]
-        call = ["module" + str(n) for n in num]
-        call_str = ", ".join(x for x in call)
-
-        # assign tuple if multiple imports
-        names_str = (
-            names_str if len(names_list) == 1 else "(" + names_str + ")"
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.ImportFromStmt) -> str:
+        """Handle ImportFromStmt nodes."""
+        names = [self.visit(name) for name in node.names]
+        level_dots = "." * node.level
+        module_str = (
+            f"{level_dots}{node.module}" if node.module else level_dots
         )
-
-        return f"{call_str} = {names_str}"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: Type[astx.Int32]) -> str:
-        """Handle Int32 nodes."""
-        return "int"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.LiteralBoolean) -> str:
-        """Handle LiteralBoolean nodes."""
-        return "True" if node.value else "False"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.LiteralInt32) -> str:
-        """Handle LiteralInt32 nodes."""
-        return str(node.value)
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.Function) -> str:
-        """Handle Function nodes."""
-        args = self.visit(node.prototype.args)
-        returns = (
-            f" -> {self.visit(node.prototype.return_type)}"
-            if node.prototype.return_type
-            else ""
-        )
-        header = f"def {node.name}({args}){returns}:"
-        body = self.visit(node.body)
-        return f"{header}\n{body}"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.FunctionReturn) -> str:
-        """Handle FunctionReturn nodes."""
-        value = self.visit(node.value) if node.value else ""
-        return f"return {value}"
+        names_str = ", ".join(str(name) for name in names)
+        return f"from {module_str} import {names_str}"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.LambdaExpr) -> str:
@@ -195,44 +180,23 @@ class ASTxPythonTranspiler:
         return f"lambda {params_str}: {self.visit(node.body)}"
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.TypeCastExpr) -> str:
-        """Handle TypeCastExpr nodes."""
-        return (
-            f"cast({self.visit(node.target_type.__class__)}, {node.expr.name})"
-        )
+    def visit(self, node: astx.LiteralBoolean) -> str:
+        """Handle LiteralBoolean nodes."""
+        return "True" if node.value else "False"
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.UnaryOp) -> str:
-        """Handle UnaryOp nodes."""
-        operand = self.visit(node.operand)
-        return f"({node.op_code}{operand})"
+    def visit(self, node: astx.LiteralComplex32) -> str:
+        """Handle LiteralComplex32 nodes."""
+        real = node.value.real
+        imag = node.value.imag
+        return f"complex({real}, {imag})"
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.Variable) -> str:
-        """Handle Variable nodes."""
-        return node.name
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.VariableAssignment) -> str:
-        """Handle VariableAssignment nodes."""
-        target = node.name
-        value = self.visit(node.value)
-        return f"{target} = {value}"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: Type[astx.Float16]) -> str:
-        """Handle Float nodes."""
-        return "float"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: Type[astx.Float32]) -> str:
-        """Handle Float nodes."""
-        return "float"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: Type[astx.Float64]) -> str:
-        """Handle Float nodes."""
-        return "float"
+    def visit(self, node: astx.LiteralComplex64) -> str:
+        """Handle LiteralComplex64 nodes."""
+        real = node.value.real
+        imag = node.value.imag
+        return f"complex({real}, {imag})"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.LiteralFloat16) -> str:
@@ -250,38 +214,9 @@ class ASTxPythonTranspiler:
         return str(node.value)
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: Type[astx.Complex32]) -> str:
-        """Handle Complex32 nodes."""
-        return "Complex"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: Type[astx.Complex64]) -> str:
-        """Handle Complex64 nodes."""
-        return "Complex"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.LiteralComplex32) -> str:
-        """Handle LiteralComplex32 nodes."""
-        real = node.value.real
-        imag = node.value.imag
-        return f"complex({real}, {imag})"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.LiteralComplex64) -> str:
-        """Handle LiteralComplex64 nodes."""
-        real = node.value.real
-        imag = node.value.imag
-        return f"complex({real}, {imag})"
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.UTF8String) -> str:
-        """Handle UTF8String nodes."""
-        return repr(node.value)
-
-    @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.UTF8Char) -> str:
-        """Handle UTF8Char nodes."""
-        return repr(node.value)
+    def visit(self, node: astx.LiteralInt32) -> str:
+        """Handle LiteralInt32 nodes."""
+        return str(node.value)
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.LiteralUTF8String) -> str:
@@ -294,6 +229,80 @@ class ASTxPythonTranspiler:
         return repr(node.value)
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.LiteralBoolean) -> str:
-        """Handle LiteralBoolean nodes."""
-        return "True" if node.value else "False"
+    def visit(self, node: Type[astx.Complex32]) -> str:
+        """Handle Complex32 nodes."""
+        return "Complex"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: Type[astx.Complex64]) -> str:
+        """Handle Complex64 nodes."""
+        return "Complex"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: Type[astx.Float16]) -> str:
+        """Handle Float nodes."""
+        return "float"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: Type[astx.Float32]) -> str:
+        """Handle Float nodes."""
+        return "float"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: Type[astx.Float64]) -> str:
+        """Handle Float nodes."""
+        return "float"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: Type[astx.Int32]) -> str:
+        """Handle Int32 nodes."""
+        return "int"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.TypeCastExpr) -> str:
+        """Handle TypeCastExpr nodes."""
+        return (
+            f"cast({self.visit(node.target_type.__class__)}, {node.expr.name})"
+        )
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.UnaryOp) -> str:
+        """Handle UnaryOp nodes."""
+        operand = self.visit(node.operand)
+        return f"({node.op_code}{operand})"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.UTF8Char) -> str:
+        """Handle UTF8Char nodes."""
+        return repr(node.value)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.UTF8String) -> str:
+        """Handle UTF8String nodes."""
+        return repr(node.value)
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.Variable) -> str:
+        """Handle Variable nodes."""
+        return node.name
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.VariableAssignment) -> str:
+        """Handle VariableAssignment nodes."""
+        target = node.name
+        value = self.visit(node.value)
+        return f"{target} = {value}"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.WhileExpr) -> str:
+        """Handle WhileExpr nodes."""
+        condition = self.visit(node.condition)
+        body = self.visit(node.body)
+        return f"[{body} for _ in iter(lambda: {condition}, False)]"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.WhileStmt) -> str:
+        """Handle WhileStmt nodes."""
+        condition = self.visit(node.condition)
+        body = self._generate_block(node.body)
+        return f"while {condition}:\n{body}"

--- a/tests/examples/test_fibonacci.py
+++ b/tests/examples/test_fibonacci.py
@@ -69,7 +69,7 @@ def test_function_call_fibonacci() -> None:
     loop_block.append(inc_i)
 
     # Create the loop statement
-    loop = astx.While(condition=cond, body=loop_block)
+    loop = astx.WhileStmt(condition=cond, body=loop_block)
     fib_block.append(loop)
 
     # Add return statement

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,5 +1,6 @@
 """Tests for control flow statements."""
 
+from astx.base import SourceLocation
 from astx.blocks import Block
 from astx.datatypes import Int32, LiteralInt32
 from astx.flows import (
@@ -8,6 +9,8 @@ from astx.flows import (
     ForRangeLoopExpr,
     ForRangeLoopStmt,
     If,
+    WhileExpr,
+    WhileStmt,
 )
 from astx.operators import BinaryOp, UnaryOp
 from astx.variables import InlineVariableDeclaration, Variable
@@ -113,3 +116,51 @@ def test_for_count_loop_expr() -> None:
     assert for_expr.get_struct()
     assert for_expr.get_struct(simplified=True)
     visualize(for_expr.get_struct())
+
+
+def test_while_expr() -> None:
+    """Test `WhileExpr` class."""
+    # Define a condition: x < 5
+    x_var = Variable(name="x")
+    condition = BinaryOp(
+        op_code="<",
+        lhs=x_var,
+        rhs=LiteralInt32(5),
+        loc=SourceLocation(line=1, col=0),
+    )
+
+    body_block = Block(name="while_body")
+
+    # Create the WhileExpr
+    while_expr = WhileExpr(
+        condition=condition, body=body_block, loc=SourceLocation(line=1, col=0)
+    )
+
+    assert str(while_expr)
+    assert while_expr.get_struct()
+    assert while_expr.get_struct(simplified=True)
+    visualize(while_expr.get_struct())
+
+
+def test_while_stmt() -> None:
+    """Test `WhileStmt` class."""
+    # Define a condition: x < 5
+    x_var = Variable(name="x")
+    condition = BinaryOp(
+        op_code="<",
+        lhs=x_var,
+        rhs=LiteralInt32(5),
+        loc=SourceLocation(line=1, col=0),
+    )
+
+    body_block = Block(name="while_body")
+
+    # Create the WhileStmt
+    while_stmt = WhileStmt(
+        condition=condition, body=body_block, loc=SourceLocation(line=1, col=0)
+    )
+
+    assert str(while_stmt)
+    assert while_stmt.get_struct()
+    assert while_stmt.get_struct(simplified=True)
+    visualize(while_stmt.get_struct())

--- a/tests/transpilers/test_python.py
+++ b/tests/transpilers/test_python.py
@@ -505,3 +505,97 @@ def test_transpiler_binary_op() -> None:
     assert (
         generated_code == expected_code
     ), f"Expected '{expected_code}', but got '{generated_code}'"
+
+
+def test_transpiler_while_stmt() -> None:
+    """Test astx.WhileStmt."""
+    # Define a condition: x < 5
+    x_var = astx.Variable(name="x")
+    condition = astx.BinaryOp(
+        op_code="<",
+        lhs=x_var,
+        rhs=astx.LiteralInt32(5),
+        loc=astx.SourceLocation(line=1, col=0),
+    )
+
+    # Define the loop body: x = x + 1
+    update_expr = astx.VariableAssignment(
+        name="x",
+        value=astx.BinaryOp(
+            op_code="+",
+            lhs=x_var,
+            rhs=astx.LiteralInt32(1),
+            loc=astx.SourceLocation(line=2, col=4),
+        ),
+        loc=astx.SourceLocation(line=2, col=4),
+    )
+
+    # Create the body block
+    body_block = astx.Block(name="while_body")
+    body_block.append(update_expr)
+
+    while_stmt = astx.WhileStmt(
+        condition=condition,
+        body=body_block,
+        loc=astx.SourceLocation(line=1, col=0),
+    )
+
+    # Initialize the generator
+    generator = astx2py.ASTxPythonTranspiler()
+
+    # Generate Python code
+    generated_code = generator.visit(while_stmt)
+
+    # Expected code for the WhileStmt
+    expected_code = "while (x < 5):\n    x = (x + 1)"
+
+    assert (
+        generated_code == expected_code
+    ), f"Expected '{expected_code}', but got '{generated_code}'"
+
+
+def test_transpiler_while_expr() -> None:
+    """Test astx.WhileExpr."""
+    # Define a condition: x < 5
+    x_var = astx.Variable(name="x")
+    condition = astx.BinaryOp(
+        op_code="<",
+        lhs=x_var,
+        rhs=astx.LiteralInt32(5),
+        loc=astx.SourceLocation(line=1, col=0),
+    )
+
+    # Define the loop body: x = x + 1
+    update_expr = astx.VariableAssignment(
+        name="x",
+        value=astx.BinaryOp(
+            op_code="+",
+            lhs=x_var,
+            rhs=astx.LiteralInt32(1),
+            loc=astx.SourceLocation(line=2, col=4),
+        ),
+        loc=astx.SourceLocation(line=2, col=4),
+    )
+
+    # Create the body block
+    body_block = astx.Block(name="while_body")
+    body_block.append(update_expr)
+
+    while_stmt = astx.WhileExpr(
+        condition=condition,
+        body=body_block,
+        loc=astx.SourceLocation(line=1, col=0),
+    )
+
+    # Initialize the generator
+    generator = astx2py.ASTxPythonTranspiler()
+
+    # Generate Python code
+    generated_code = generator.visit(while_stmt)
+
+    # Expected code for the WhileExpr
+    expected_code = "[    x = (x + 1) for _ in iter(lambda: (x < 5), False)]"
+
+    assert (
+        generated_code == expected_code
+    ), f"Expected '{expected_code}', but got '{generated_code}'"


### PR DESCRIPTION
## Pull Request description

This PR adds `WhileExpr` and modifies `While` -> `WhileStmt`. 
This PR is an attempt to resolve #96 .

- [X] added new ASTKind
- [X] created `WhileExpr` class
- [X] updated `__init__.py` to include the new imports and classes in the `__all__` list
- [X] added test for `WhileExpr`
- [X] added test for `WhileStmt` (there weren't any)
- [X] added transpiler visit methods for `WhileStmt` and `WhileExpr`
- [X] added transpiler tests for `WhileStmt` and `WhileExpr`

## How to test these changes
```python
from astx.flows import WhileExpr
from astx.blocks import Block
from astx.variables import VariableAssignment, Variable
from astx.operators import BinaryOp
from astx.base import SourceLocation
from astx.datatypes import Int32, LiteralInt32
from astx.transpilers import python as astx2py

# Define a condition: x < 5
x_var = Variable(name="x")
condition = BinaryOp(
    op_code="<",
    lhs=x_var,
    rhs=LiteralInt32(5),
    loc=SourceLocation(line=1, col=0)
)

# Define the loop body: x = x + 1
update_expr = VariableAssignment(
    name="x",
    value=BinaryOp(
        op_code="+",
        lhs=x_var,
        rhs=LiteralInt32(1),
        loc=SourceLocation(line=2, col=4)
    ),
    loc=SourceLocation(line=2, col=4)
)

# Create the body block
body_block = Block(name="while_body")
body_block.append(update_expr)

# Create the WhileExpr
while_expr = WhileExpr(
    condition=condition,
    body=body_block,
    loc=SourceLocation(line=1, col=0)
)

# AST representation
while_expr
while_expr.__str__()

# Initialize the generator
generator = astx2py.ASTxPythonTranspiler()

# Generate Python code
generated_code = generator.visit(while_expr)
generated_code
```

![while_expr_ascii](https://github.com/user-attachments/assets/378df70c-7533-4848-9e84-0fa74068052f)
![while_expr_png](https://github.com/user-attachments/assets/b4f8d3ff-a530-48b9-9330-008b1aad3253)

Output of `while_expr.__str__()`: `WhileExpr[BinaryOp[<](Variable[x],LiteralInt32(5))]`

Output of the transpiler: `[    x = (x + 1) for _ in iter(lambda: (x < 5), False)]`



## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [X] new feature
- [ ] maintenance

About this PR:

- [X] it includes tests.
- [X] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [X] I have reviewed the changes and it contains no misspelling.
- [X] The code is well commented, especially in the parts that contain more
      complexity.
- [X] New and old tests passed locally.

## Additional information
