### PR TITLE
feat: add `IfExpr` class

### DIFF
--- a/docs/tutorials/fibonacci.ipynb
+++ b/docs/tutorials/fibonacci.ipynb
@@ -126,7 +126,7 @@
     "base_case_return = astx.FunctionReturn(astx.Variable(name=\"n\"))\n",
     "base_case_block.append(base_case_return)\n",
     "\n",
-    "base_case_if = astx.If(condition=base_case_cond, then=base_case_block)\n",
+    "base_case_if = astx.IfStmt(condition=base_case_cond, then=base_case_block)\n",
     "\n",
     "# Recursive case: return fib(n - 1) + fib(n - 2);\n",
     "fib_n1_call = astx.FunctionCall(\n",
@@ -210,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -89,10 +89,10 @@ from astx.flows import (
     ForCountLoopStmt,
     ForRangeLoopExpr,
     ForRangeLoopStmt,
-    WhileExpr,
-    WhileStmt,
     IfExpr,
     IfStmt,
+    WhileExpr,
+    WhileStmt,
 )
 from astx.mixes import (
     NamedExpr,

--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -89,9 +89,10 @@ from astx.flows import (
     ForCountLoopStmt,
     ForRangeLoopExpr,
     ForRangeLoopStmt,
-    If,
     WhileExpr,
     WhileStmt,
+    IfExpr,
+    IfStmt,
 )
 from astx.mixes import (
     NamedExpr,
@@ -169,7 +170,8 @@ __all__ = [
     "FunctionPrototype",
     "FunctionReturn",
     "get_version",
-    "If",
+    "IfStmt",
+    "IfExpr",
     "ImportFromExpr",
     "ImportExpr",
     "ImportStmt",

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -96,13 +96,14 @@ class ASTKind(Enum):
     LambdaExprKind = -404
 
     # control flow
-    IfKind = -500
+    IfStmtKind = -500
     ForCountLoopStmtKind = -501
     ForRangeLoopStmtKind = -502
     WhileStmtKind = -503
     ForRangeLoopExprKind = -504
     ForCountLoopExprKind = -505
     WhileExprKind = -506
+    IfExprKind = -507
 
     # data types
     NullDTKind = -600

--- a/src/astx/flows.py
+++ b/src/astx/flows.py
@@ -23,7 +23,7 @@ from astx.variables import InlineVariableDeclaration
 
 @public
 @typechecked
-class If(StatementType):
+class IfStmt(StatementType):
     """AST class for `if` statement."""
 
     condition: Expr
@@ -38,17 +38,17 @@ class If(StatementType):
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
     ) -> None:
-        """Initialize the If instance."""
+        """Initialize the IfStmt instance."""
         super().__init__(loc=loc, parent=parent)
         self.loc = loc
         self.condition = condition
         self.then = then
         self.else_ = else_
-        self.kind = ASTKind.IfKind
+        self.kind = ASTKind.IfStmtKind
 
     def __str__(self) -> str:
         """Return a string representation of the object."""
-        return f"If[{self.condition}]"
+        return f"IfStmt[{self.condition}]"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
@@ -60,6 +60,54 @@ class If(StatementType):
             if_else = {"else-block": self.else_.get_struct(simplified)}
 
         key = "IF-STMT"
+        value: ReprStruct = {
+            **cast(DictDataTypesStruct, if_condition),
+            **cast(DictDataTypesStruct, if_then),
+            **cast(DictDataTypesStruct, if_else),
+        }
+
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class IfExpr(Expr):
+    """AST class for `if` expression."""
+
+    condition: Expr
+    then: Block
+    else_: Optional[Block]
+
+    def __init__(
+        self,
+        condition: Expr,
+        then: Block,
+        else_: Optional[Block] = None,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the IfExpr instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.loc = loc
+        self.condition = condition
+        self.then = then
+        self.else_ = else_
+        self.kind = ASTKind.IfExprKind
+
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        return f"IfExpr[{self.condition}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        if_condition = {"condition": self.condition.get_struct(simplified)}
+        if_then = {"then-block": self.then.get_struct(simplified)}
+        if_else: ReprStruct = {}
+
+        if self.else_ is not None:
+            if_else = {"else-block": self.else_.get_struct(simplified)}
+
+        key = "IF-EXPR"
         value: ReprStruct = {
             **cast(DictDataTypesStruct, if_condition),
             **cast(DictDataTypesStruct, if_then),

--- a/src/astx/transpilers/python.py
+++ b/src/astx/transpilers/python.py
@@ -100,6 +100,7 @@ class ASTxPythonTranspiler:
         value = self.visit(node.value) if node.value else ""
         return f"return {value}"
 
+    @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.IfExpr) -> str:
         """Handle IfExpr nodes."""
         if node.else_:

--- a/src/astx/transpilers/python.py
+++ b/src/astx/transpilers/python.py
@@ -109,7 +109,10 @@ class ASTxPythonTranspiler:
                 f" {self.visit(node.condition)}"
                 f" else {self.visit(node.else_)}"
             )
-        return f"{self.visit(node.then)} if " f" {self.visit(node.condition)}"
+        return (
+            f"{self.visit(node.then)} if "
+            f" {self.visit(node.condition)} else None"
+        )
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.IfStmt) -> str:

--- a/src/astx/transpilers/python.py
+++ b/src/astx/transpilers/python.py
@@ -100,6 +100,42 @@ class ASTxPythonTranspiler:
         value = self.visit(node.value) if node.value else ""
         return f"return {value}"
 
+    def visit(self, node: astx.IfExpr) -> str:
+        """Handle IfExpr nodes."""
+        if node.else_:
+            return (
+                f"{self.visit(node.then)} if "
+                f" {self.visit(node.condition)}"
+                f" else {self.visit(node.else_)}"
+            )
+        return f"{self.visit(node.then)} if " f" {self.visit(node.condition)}"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.IfStmt) -> str:
+        """Handle IfStmt nodes."""
+        if node.else_:
+            return (
+                f"if {self.visit(node.condition)}:"
+                f"\n{self._generate_block(node.then)}"
+                f"\nelse:"
+                f"\n{self._generate_block(node.else_)}"
+            )
+        return (
+            f"if {self.visit(node.condition)}:"
+            f"\n{self._generate_block(node.then)}"
+        )
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.ImportFromStmt) -> str:
+        """Handle ImportFromStmt nodes."""
+        names = [self.visit(name) for name in node.names]
+        level_dots = "." * node.level
+        module_str = (
+            f"{level_dots}{node.module}" if node.module else level_dots
+        )
+        names_str = ", ".join(str(name) for name in names)
+        return f"from {module_str} import {names_str}"
+
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.ImportExpr) -> str:
         """Handle ImportExpr nodes."""

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -8,20 +8,21 @@ from astx.flows import (
     ForCountLoopStmt,
     ForRangeLoopExpr,
     ForRangeLoopStmt,
-    If,
     WhileExpr,
     WhileStmt,
+    IfExpr,
+    IfStmt,
 )
 from astx.operators import BinaryOp, UnaryOp
 from astx.variables import InlineVariableDeclaration, Variable
 from astx.viz import visualize
 
 
-def test_if() -> None:
+def test_if_stmt() -> None:
     """Test `if` statement."""
     op = BinaryOp(op_code=">", lhs=LiteralInt32(1), rhs=LiteralInt32(2))
     then_block = Block()
-    if_stmt = If(condition=op, then=then_block)
+    if_stmt = IfStmt(condition=op, then=then_block)
 
     assert str(if_stmt)
     assert if_stmt.get_struct()
@@ -29,17 +30,42 @@ def test_if() -> None:
     visualize(if_stmt.get_struct())
 
 
-def test_if_else() -> None:
+def test_if_else_stmt() -> None:
     """Test `if`/`else` statement."""
     cond = BinaryOp(op_code=">", lhs=LiteralInt32(1), rhs=LiteralInt32(2))
     then_block = Block()
     else_block = Block()
-    if_stmt = If(condition=cond, then=then_block, else_=else_block)
+    if_stmt = IfStmt(condition=cond, then=then_block, else_=else_block)
 
     assert str(if_stmt)
     assert if_stmt.get_struct()
     assert if_stmt.get_struct(simplified=True)
     visualize(if_stmt.get_struct())
+
+
+def test_if_expr() -> None:
+    """Test `if` expression."""
+    op = BinaryOp(op_code=">", lhs=LiteralInt32(1), rhs=LiteralInt32(2))
+    then_block = Block()
+    if_expr = IfExpr(condition=op, then=then_block)
+
+    assert str(if_expr)
+    assert if_expr.get_struct()
+    assert if_expr.get_struct(simplified=True)
+    visualize(if_expr.get_struct())
+
+
+def test_if_else_expr() -> None:
+    """Test `if`/`else` expression."""
+    cond = BinaryOp(op_code=">", lhs=LiteralInt32(1), rhs=LiteralInt32(2))
+    then_block = Block()
+    else_block = Block()
+    if_expr = IfExpr(condition=cond, then=then_block, else_=else_block)
+
+    assert str(if_expr)
+    assert if_expr.get_struct()
+    assert if_expr.get_struct(simplified=True)
+    visualize(if_expr.get_struct())
 
 
 def test_for_range_loop_expr() -> None:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -8,10 +8,10 @@ from astx.flows import (
     ForCountLoopStmt,
     ForRangeLoopExpr,
     ForRangeLoopStmt,
-    WhileExpr,
-    WhileStmt,
     IfExpr,
     IfStmt,
+    WhileExpr,
+    WhileStmt,
 )
 from astx.operators import BinaryOp, UnaryOp
 from astx.variables import InlineVariableDeclaration, Variable

--- a/tests/transpilers/test_python.py
+++ b/tests/transpilers/test_python.py
@@ -554,6 +554,46 @@ def test_transpiler_while_stmt() -> None:
     ), f"Expected '{expected_code}', but got '{generated_code}'"
 
 
+def test_transpiler_ifexpr_with_else() -> None:
+    """Test astx.IfExpr with else block."""
+    # determine condition
+    cond = astx.BinaryOp(
+        op_code=">", lhs=astx.LiteralInt32(1), rhs=astx.LiteralInt32(2)
+    )
+
+    # create then and else blocks
+    then_block = astx.Block()
+    else_block = astx.Block()
+
+    # define literals
+    lit_2 = astx.LiteralInt32(2)
+    lit_3 = astx.LiteralInt32(3)
+
+    # define operations
+    op1 = lit_2 + lit_3
+    op2 = lit_2 - lit_3
+
+    # Add statements to the then and else blocks
+    then_block.append(op1)
+    else_block.append(op2)
+
+    # define if Expr
+    if_expr = astx.IfExpr(condition=cond, then=then_block, else_=else_block)
+
+    # Initialize the generator
+    generator = astx2py.ASTxPythonTranspiler()
+
+    # Generate Python code
+    generated_code = generator.visit(if_expr)
+
+    # Expected code for the binary operation
+    expected_code = "result =     (2 + 3) if  (1 > 2) else     (2 - 3)"
+
+    assert (
+        generated_code == expected_code
+    ), f"Expected '{expected_code}', but got '{generated_code}'"
+
+
 def test_transpiler_while_expr() -> None:
     """Test astx.WhileExpr."""
     # Define a condition: x < 5
@@ -595,6 +635,120 @@ def test_transpiler_while_expr() -> None:
 
     # Expected code for the WhileExpr
     expected_code = "[    x = (x + 1) for _ in iter(lambda: (x < 5), False)]"
+
+    assert (
+        generated_code == expected_code
+    ), f"Expected '{expected_code}', but got '{generated_code}'"
+
+
+def test_transpiler_ifexpr_without_else() -> None:
+    """Test astx.IfExpr without else block."""
+    # determine condition
+    cond = astx.BinaryOp(
+        op_code=">", lhs=astx.LiteralInt32(1), rhs=astx.LiteralInt32(2)
+    )
+
+    # create then block
+    then_block = astx.Block()
+
+    # define literals
+    lit_2 = astx.LiteralInt32(2)
+    lit_3 = astx.LiteralInt32(3)
+
+    # define operation
+    op1 = lit_2 + lit_3
+
+    # Add statement to the then block
+    then_block.append(op1)
+
+    # define if Expr
+    if_expr = astx.IfExpr(condition=cond, then=then_block)
+
+    # Initialize the generator
+    generator = astx2py.ASTxPythonTranspiler()
+
+    # Generate Python code
+    generated_code = generator.visit(if_expr)
+
+    # Expected code for the binary operation
+    expected_code = "result =     (2 + 3) if  (1 > 2)"
+
+    assert (
+        generated_code == expected_code
+    ), f"Expected '{expected_code}', but got '{generated_code}'"
+
+
+def test_transpiler_ifstmt_with_else() -> None:
+    """Test astx.IfStmt with else block."""
+    # determine condition
+    cond = astx.BinaryOp(
+        op_code=">", lhs=astx.LiteralInt32(1), rhs=astx.LiteralInt32(2)
+    )
+
+    # create then and else blocks
+    then_block = astx.Block()
+    else_block = astx.Block()
+
+    # define literals
+    lit_2 = astx.LiteralInt32(2)
+    lit_3 = astx.LiteralInt32(3)
+
+    # define operations
+    op1 = lit_2 + lit_3
+    op2 = lit_2 - lit_3
+
+    # Add statements to the then and else blocks
+    then_block.append(op1)
+    else_block.append(op2)
+
+    # define if Stmt
+    if_stmt = astx.IfStmt(condition=cond, then=then_block, else_=else_block)
+
+    # Initialize the generator
+    generator = astx2py.ASTxPythonTranspiler()
+
+    # Generate Python code
+    generated_code = generator.visit(if_stmt)
+
+    # Expected code for the binary operation
+    expected_code = "if (1 > 2):\n    (2 + 3)\nelse:\n    (2 - 3)"
+
+    assert (
+        generated_code == expected_code
+    ), f"Expected '{expected_code}', but got '{generated_code}'"
+
+
+def test_transpiler_ifstmt_without_else() -> None:
+    """Test astx.IfStmt without else block."""
+    # determine condition
+    cond = astx.BinaryOp(
+        op_code=">", lhs=astx.LiteralInt32(1), rhs=astx.LiteralInt32(2)
+    )
+
+    # create then block
+    then_block = astx.Block()
+
+    # define literals
+    lit_2 = astx.LiteralInt32(2)
+    lit_3 = astx.LiteralInt32(3)
+
+    # define operation
+    op1 = lit_2 + lit_3
+
+    # Add statement to the then block
+    then_block.append(op1)
+
+    # define if Stmt
+    if_stmt = astx.IfStmt(condition=cond, then=then_block)
+
+    # Initialize the generator
+    generator = astx2py.ASTxPythonTranspiler()
+
+    # Generate Python code
+    generated_code = generator.visit(if_stmt)
+
+    # Expected code for the binary operation
+    expected_code = "if (1 > 2):\n    (2 + 3)"
 
     assert (
         generated_code == expected_code

--- a/tests/transpilers/test_python.py
+++ b/tests/transpilers/test_python.py
@@ -587,7 +587,7 @@ def test_transpiler_ifexpr_with_else() -> None:
     generated_code = generator.visit(if_expr)
 
     # Expected code for the binary operation
-    expected_code = "result =     (2 + 3) if  (1 > 2) else     (2 - 3)"
+    expected_code = "    (2 + 3) if  (1 > 2) else     (2 - 3)"
 
     assert (
         generated_code == expected_code
@@ -671,7 +671,7 @@ def test_transpiler_ifexpr_without_else() -> None:
     generated_code = generator.visit(if_expr)
 
     # Expected code for the binary operation
-    expected_code = "result =     (2 + 3) if  (1 > 2)"
+    expected_code = "    (2 + 3) if  (1 > 2)"
 
     assert (
         generated_code == expected_code

--- a/tests/transpilers/test_python.py
+++ b/tests/transpilers/test_python.py
@@ -671,7 +671,7 @@ def test_transpiler_ifexpr_without_else() -> None:
     generated_code = generator.visit(if_expr)
 
     # Expected code for the binary operation
-    expected_code = "    (2 + 3) if  (1 > 2)"
+    expected_code = "    (2 + 3) if  (1 > 2) else None"
 
     assert (
         generated_code == expected_code


### PR DESCRIPTION
## Pull Request description

This PR adds `IfExpr` and modifies `If` -> `IfStmt`. 
This PR is an attempt to resolve #93  .

- [X] added new ASTKind
- [X] created `IfExpr` class
- [X] updated `__init__.py` to include the new imports and classes in the `__all__` list
- [X] added test for `IfExpr`
- [X] added transpiler visit method for `IfExpr`
- [X] added transpiler test for `IfExpr`
- [X] added transpiler visit method for `IfStmt`
- [X] added transpiler tests for `IfStmt`

## How to test these changes
```python
from astx.operators import BinaryOp
from astx.blocks import Block
from astx.datatypes import LiteralInt32
from astx.flows import IfExpr
from astx.transpilers import python as astx2py

# determine condition
cond = BinaryOp(op_code=">", lhs=LiteralInt32(1), rhs=LiteralInt32(2))

# create then and else blocks
then_block = Block()
else_block = Block()

# define literals
lit_2 = LiteralInt32(2)
lit_3 = LiteralInt32(3)

# define operations
op1 = lit_2 + lit_3
op2 = lit_2 - lit_3

# Add statements to the then and else blocks
then_block.append(op1)
else_block.append(op2)

# define if Expr
if_expr = IfExpr(condition=cond, then=then_block, else_=else_block)

if_expr
if_expr.__str__()

# Initialize the generator
generator = astx2py.ASTxPythonTranspiler()

# Generate Python code
generated_code = generator.visit(if_expr)
generated_code
```
![if_expr_ascii](https://github.com/user-attachments/assets/a9b15fe4-91d2-42e7-ab78-3032868cfcd7)
![if_expr_png](https://github.com/user-attachments/assets/bc33f553-6721-49c1-b398-689f13f69bfe)

Output of `if_expr.__str__()`: `'IfExpr[BinaryOp[>](LiteralInt32(1),LiteralInt32(2))]'`

Output of `generated_code`: `'result =     (2 + 3) if  (1 > 2) else     (2 - 3)'`
## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [X] new feature
- [ ] maintenance

About this PR:

- [X] it includes tests.
- [X] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [X] I have reviewed the changes and it contains no misspelling.
- [X] The code is well commented, especially in the parts that contain more
      complexity.
- [X] New and old tests passed locally.

## Additional information

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
