### PR TITLE
feat: add `StructDeclStmt` and `StructDefStmt` classes

### DIFF
--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -42,6 +42,8 @@ from astx.classes import (
     ClassDeclStmt,
     ClassDefStmt,
     EnumDeclStmt,
+    StructDeclStmt,
+    StructDefStmt,
 )
 from astx.flows import (
     ForCountLoopExpr,
@@ -245,6 +247,8 @@ __all__ = [
     "ClassDefStmt",
     "ClassDeclStmt",
     "EnumDeclStmt",
+    "StructDeclStmt",
+    "StructDefStmt",
     "LiteralComplex",
     "LiteralComplex32",
     "LiteralComplex64",

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -160,6 +160,9 @@ class ASTKind(Enum):
     ClassDeclStmtKind = -901
     EnumDeclStmtKind = -902
 
+    StructDeclStmtKind = -903
+    StructDefStmtKind = -904
+
 
 class ASTMeta(type):
     def __str__(cls) -> str:

--- a/src/astx/classes.py
+++ b/src/astx/classes.py
@@ -284,7 +284,7 @@ class StructDeclStmt(StatementType):
     """AST class for struct declaration."""
 
     name: str
-    fields: Iterable[VariableDeclaration]
+    attributes: Iterable[VariableDeclaration]
     visibility: VisibilityKind
     decorators: ASTNodes
     methods: ASTNodes
@@ -292,7 +292,7 @@ class StructDeclStmt(StatementType):
     def __init__(
         self,
         name: str,
-        fields: Iterable[VariableDeclaration],
+        attributes: Iterable[VariableDeclaration],
         decorators: Iterable[Expr] | ASTNodes = [],
         methods: Iterable[Function] | ASTNodes = [],
         visibility: VisibilityKind = VisibilityKind.public,
@@ -302,7 +302,7 @@ class StructDeclStmt(StatementType):
         """Initialize StructDeclStmt instance."""
         super().__init__(loc=loc, parent=parent)
         self.name = name
-        self.fields = fields
+        self.attributes = attributes
 
         if isinstance(decorators, ASTNodes):
             self.decorators = decorators
@@ -329,8 +329,8 @@ class StructDeclStmt(StatementType):
             else ""
         )
         struct_header = f"{visibility_str} struct {self.name}".strip()
-        fields_str = "\n    ".join(str(field) for field in self.fields)
-        return f"{decorators_str}{struct_header} {{\n    {fields_str}\n}}"
+        attributes_str = "\n    ".join(str(attr) for attr in self.attributes)
+        return f"{decorators_str}{struct_header} {{\n    {attributes_str}\n}}"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
@@ -344,7 +344,9 @@ class StructDeclStmt(StatementType):
             }
 
         value: DictDataTypesStruct = {
-            "fields": [field.get_struct(simplified) for field in self.fields],
+            "attributes": [
+                attr.get_struct(simplified) for attr in self.attributes
+            ],
             **cast(DictDataTypesStruct, decors_dict),
         }
         return self._prepare_struct(key, value, simplified)
@@ -358,7 +360,7 @@ class StructDefStmt(StructDeclStmt):
     def __init__(
         self,
         name: str,
-        fields: Iterable[VariableDeclaration],
+        attributes: Iterable[VariableDeclaration],
         decorators: Iterable[Expr] | ASTNodes = [],
         methods: Iterable[Function] | ASTNodes = [],
         visibility: VisibilityKind = VisibilityKind.public,
@@ -368,7 +370,7 @@ class StructDefStmt(StructDeclStmt):
         """Initialize StructDefStmt instance."""
         super().__init__(
             name=name,
-            fields=fields,
+            attributes=attributes,
             decorators=decorators,
             methods=methods,
             visibility=visibility,
@@ -388,8 +390,8 @@ class StructDefStmt(StructDeclStmt):
             else ""
         )
         struct_header = f"{visibility_str} struct {self.name}".strip()
-        fields_str = "\n    ".join(str(field) for field in self.fields)
-        return f"{decorators_str}{struct_header} {{\n    {fields_str}\n}}"
+        attributes_str = "\n    ".join(str(attr) for attr in self.attributes)
+        return f"{decorators_str}{struct_header} {{\n    {attributes_str}\n}}"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
@@ -403,7 +405,9 @@ class StructDefStmt(StructDeclStmt):
             }
 
         value: DictDataTypesStruct = {
-            "fields": [field.get_struct(simplified) for field in self.fields],
+            "attributes": [
+                attr.get_struct(simplified) for attr in self.attributes
+            ],
             **cast(DictDataTypesStruct, decors_dict),
         }
         return self._prepare_struct(key, value, simplified)

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -289,7 +289,9 @@ class ASTxPythonTranspiler:
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.StructDeclStmt) -> str:
         """Handle StructDeclStmt nodes."""
-        fields_str = "\n    ".join(self.visit(field) for field in node.fields)
+        fields_str = "\n    ".join(
+            self.visit(attr) for attr in node.attributes
+        )
         return f"@dataclass {node.name}:\n    {fields_str}"
 
     @dispatch  # type: ignore[no-redef]

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -289,10 +289,8 @@ class ASTxPythonTranspiler:
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.StructDeclStmt) -> str:
         """Handle StructDeclStmt nodes."""
-        fields_str = "\n    ".join(
-            self.visit(attr) for attr in node.attributes
-        )
-        return f"@dataclass {node.name}:\n    {fields_str}"
+        attrs_str = "\n    ".join(self.visit(attr) for attr in node.attributes)
+        return f"@dataclass \n{node.name}:\n    {attrs_str}"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.Complex32) -> str:

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -1,5 +1,7 @@
 """ASTx Python transpiler."""
 
+from typing import Union
+
 from plum import dispatch
 
 import astx
@@ -287,8 +289,10 @@ class ASTxPythonTranspiler:
         return repr(node.value)
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.StructDeclStmt) -> str:
-        """Handle StructDeclStmt nodes."""
+    def visit(
+        self, node: Union[astx.StructDeclStmt, astx.StructDefStmt]
+    ) -> str:
+        """Handle StructDeclStmt and StructDefStmt nodes."""
         attrs_str = "\n    ".join(self.visit(attr) for attr in node.attributes)
         return f"@dataclass \n{node.name}:\n    {attrs_str}"
 

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -287,6 +287,12 @@ class ASTxPythonTranspiler:
         return repr(node.value)
 
     @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.StructDeclStmt) -> str:
+        """Handle StructDeclStmt nodes."""
+        fields_str = "\n    ".join(self.visit(field) for field in node.fields)
+        return f"@dataclass {node.name}:\n    {fields_str}"
+
+    @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.Complex32) -> str:
         """Handle Complex32 nodes."""
         return "Complex"

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -294,7 +294,7 @@ class ASTxPythonTranspiler:
     ) -> str:
         """Handle StructDeclStmt and StructDefStmt nodes."""
         attrs_str = "\n    ".join(self.visit(attr) for attr in node.attributes)
-        return f"@dataclass \n{node.name}:\n    {attrs_str}"
+        return f"@dataclass \nclass {node.name}:\n    {attrs_str}"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.Complex32) -> str:

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -3,8 +3,18 @@
 from astx.base import DataType
 from astx.blocks import Block
 from astx.callables import Arguments, Function, FunctionPrototype
+<<<<<<< HEAD
 from astx.classes import ClassDeclStmt, ClassDefStmt, EnumDeclStmt
 from astx.literals.numeric import LiteralInt32
+=======
+from astx.classes import (
+    ClassDeclStmt,
+    ClassDefStmt,
+    StructDeclStmt,
+    StructDefStmt,
+)
+from astx.literals import LiteralInt32
+>>>>>>> afc48b5 (add structdecl and structdef classes)
 from astx.types.base import AnyType
 from astx.variables import Variable, VariableDeclaration
 from astx.viz import visualize
@@ -61,7 +71,6 @@ def test_class_def() -> None:
     assert class_def.get_struct(simplified=True)
     visualize(class_def.get_struct())
 
-
 def test_enum_decl() -> None:
     """Test `EnumDeclStmt` class."""
     # Enum attributes
@@ -93,3 +102,49 @@ def test_enum_decl() -> None:
     assert enum_decl.get_struct()
     assert enum_decl.get_struct(simplified=True)
     visualize(enum_decl.get_struct())
+
+def test_struct_decl() -> None:
+    """Test `StructDeclStmt` class."""
+    # Define struct fields
+    field1 = VariableDeclaration(name="id", type_=DataType())
+
+    field2 = VariableDeclaration(name="value", type_=DataType())
+
+    # create decorator
+    decorator1 = Variable(name="decorator_one")
+
+    # Create struct declaration
+    struct_decl = StructDeclStmt(
+        name="DataPoint",
+        fields=[field1, field2],
+        decorators=[decorator1],
+    )
+
+    assert str(struct_decl)
+    assert struct_decl.get_struct()
+    assert struct_decl.get_struct(simplified=True)
+    visualize(struct_decl.get_struct())
+
+
+def test_struct_def() -> None:
+    """Test `StructDefStmt` class."""
+    # Define struct fields
+    field1 = VariableDeclaration(name="id", type_=DataType())
+
+    field2 = VariableDeclaration(name="value", type_=DataType())
+
+    # create decorator
+    decorator1 = Variable(name="decorator_one")
+
+    # Create struct declaration
+    struct_def = StructDefStmt(
+        name="DataPoint",
+        fields=[field1, field2],
+        decorators=[decorator1],
+    )
+
+    assert str(struct_def)
+    assert struct_def.get_struct()
+    assert struct_def.get_struct(simplified=True)
+    visualize(struct_def.get_struct())
+

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -3,18 +3,14 @@
 from astx.base import DataType
 from astx.blocks import Block
 from astx.callables import Arguments, Function, FunctionPrototype
-<<<<<<< HEAD
-from astx.classes import ClassDeclStmt, ClassDefStmt, EnumDeclStmt
-from astx.literals.numeric import LiteralInt32
-=======
 from astx.classes import (
     ClassDeclStmt,
     ClassDefStmt,
+    EnumDeclStmt,
     StructDeclStmt,
     StructDefStmt,
 )
 from astx.literals import LiteralInt32
->>>>>>> afc48b5 (add structdecl and structdef classes)
 from astx.types.base import AnyType
 from astx.variables import Variable, VariableDeclaration
 from astx.viz import visualize
@@ -71,6 +67,7 @@ def test_class_def() -> None:
     assert class_def.get_struct(simplified=True)
     visualize(class_def.get_struct())
 
+
 def test_enum_decl() -> None:
     """Test `EnumDeclStmt` class."""
     # Enum attributes
@@ -102,6 +99,7 @@ def test_enum_decl() -> None:
     assert enum_decl.get_struct()
     assert enum_decl.get_struct(simplified=True)
     visualize(enum_decl.get_struct())
+
 
 def test_struct_decl() -> None:
     """Test `StructDeclStmt` class."""
@@ -147,4 +145,3 @@ def test_struct_def() -> None:
     assert struct_def.get_struct()
     assert struct_def.get_struct(simplified=True)
     visualize(struct_def.get_struct())
-

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -106,9 +106,9 @@ def test_enum_decl() -> None:
 def test_struct_decl() -> None:
     """Test `StructDeclStmt` class."""
     # Define struct fields
-    field1 = VariableDeclaration(name="id", type_=DataType())
+    attr1 = VariableDeclaration(name="id", type_=DataType())
 
-    field2 = VariableDeclaration(name="value", type_=DataType())
+    attr2 = VariableDeclaration(name="value", type_=DataType())
 
     # create decorator
     decorator1 = Variable(name="decorator_one")
@@ -116,7 +116,7 @@ def test_struct_decl() -> None:
     # Create struct declaration
     struct_decl = StructDeclStmt(
         name="DataPoint",
-        fields=[field1, field2],
+        attributes=[attr1, attr2],
         decorators=[decorator1],
     )
 
@@ -129,9 +129,9 @@ def test_struct_decl() -> None:
 def test_struct_def() -> None:
     """Test `StructDefStmt` class."""
     # Define struct fields
-    field1 = VariableDeclaration(name="id", type_=DataType())
+    attr1 = VariableDeclaration(name="id", type_=DataType())
 
-    field2 = VariableDeclaration(name="value", type_=DataType())
+    attr2 = VariableDeclaration(name="value", type_=DataType())
 
     # create decorator
     decorator1 = Variable(name="decorator_one")
@@ -139,7 +139,7 @@ def test_struct_def() -> None:
     # Create struct declaration
     struct_def = StructDefStmt(
         name="DataPoint",
-        fields=[field1, field2],
+        attributes=[attr1, attr2],
         decorators=[decorator1],
     )
 

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -840,7 +840,7 @@ def test_transpiler_variabledeclaration() -> None:
 
 def test_transpiler_structdeclstmt() -> None:
     """Test astx.StructDeclStmt."""
-    # Define struct fields
+    # Define struct attributes
     attr1 = astx.VariableDeclaration(
         name="id",
         type_=astx.DataType(),
@@ -865,7 +865,44 @@ def test_transpiler_structdeclstmt() -> None:
     # Generate Python code
     generated_code = transpiler.visit(struct_decl)
     expected_code = (
-        "@dataclass \nDataPoint:\n    id: Int32 = 3\n    value: Int32 = 1"
+        "@dataclass \nclass DataPoint:\n    id: Int32 = 3\n    "
+        "value: Int32 = 1"
+    )
+
+    assert (
+        generated_code == expected_code
+    ), f"Expected '{expected_code}', but got '{generated_code}'"
+
+
+def test_transpiler_structdefstmt() -> None:
+    """Test astx.StructDefStmt."""
+    # Define struct attributes
+    attr1 = astx.VariableDeclaration(
+        name="id",
+        type_=astx.DataType(),
+        value=astx.LiteralInt32(3),
+    )
+
+    attr2 = astx.VariableDeclaration(
+        name="value",
+        type_=astx.DataType(),
+        value=astx.LiteralInt32(1),
+    )
+
+    decorator1 = astx.Variable(name="decorator_one")
+
+    # Create struct declaration
+    struct_def = astx.StructDefStmt(
+        name="DataPoint",
+        attributes=[attr1, attr2],
+        decorators=[decorator1],
+    )
+
+    # Generate Python code
+    generated_code = transpiler.visit(struct_def)
+    expected_code = (
+        "@dataclass \nclass DataPoint:\n    id: Int32 = 3\n    "
+        "value: Int32 = 1"
     )
 
     assert (

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -836,3 +836,38 @@ def test_transpiler_variabledeclaration() -> None:
     assert (
         generated_code == expected_code
     ), f"Expected '{expected_code}', but got '{generated_code}'"
+
+
+def test_transpiler_structdeclstmt() -> None:
+    """Test astx.StructDeclStmt."""
+    # Define struct fields
+    attr1 = astx.VariableDeclaration(
+        name="id",
+        type_=astx.DataType(),
+        value=astx.LiteralInt32(3),
+    )
+
+    attr2 = astx.VariableDeclaration(
+        name="value",
+        type_=astx.DataType(),
+        value=astx.LiteralInt32(1),
+    )
+
+    decorator1 = astx.Variable(name="decorator_one")
+
+    # Create struct declaration
+    struct_decl = astx.StructDeclStmt(
+        name="DataPoint",
+        attributes=[attr1, attr2],
+        decorators=[decorator1],
+    )
+
+    # Generate Python code
+    generated_code = transpiler.visit(struct_decl)
+    expected_code = (
+        "@dataclass \nDataPoint:\n    id: Int32 = 3\n    value: Int32 = 1"
+    )
+
+    assert (
+        generated_code == expected_code
+    ), f"Expected '{expected_code}', but got '{generated_code}'"


### PR DESCRIPTION
## Pull Request description

This PR adds `StructDeclStmt` and `StructDefStmt` classes. 
This PR is an attempt to resolve #92  .

- [X] added new ASTKind's
- [X] created `StructDeclStmt` class
- [X] created `StructDefStmt` class
- [X] updated `__init__.py` to include the new imports and classes in the `__all__` list
- [X] added test for `StructDeclStmt` class
- [X] added test for `StructDefStmt` class
- [ ] added transpiler visit method for `StructDefStmt`
- [ ] added transpiler test for `StructDefStmt`


## How to test these changes
```python
from astx.classes import StructDeclStmt
from astx.variables import VariableDeclaration, Variable
from astx.base import DataType

# Define struct fields
field1 = VariableDeclaration(
    name="id",
    type_=DataType()
)

field2 = VariableDeclaration(
    name="value",
    type_=DataType()
)

decorator1 = Variable(name="decorator_one")

# Create struct declaration
struct_decl = StructDeclStmt(
    name="DataPoint",
    fields=[field1, field2],
    decorators=[decorator1],
)

# Print the string representation
struct_decl
print(struct_decl)
```
![struct_decl](https://github.com/user-attachments/assets/0076dc45-c357-4870-a269-1ada84a5c6a0)

![struct_decl_ipynb](https://github.com/user-attachments/assets/4adf9bc2-1897-4432-af4f-cec906279727)

```
@Variable[decorator_one]
struct DataPoint {
    VariableDeclaration[id, DataType]
    VariableDeclaration[value, DataType]
}
```

```python
from astx.classes import StructDefStmt
from astx.variables import VariableDeclaration, Variable
from astx.base import DataType

# Define struct fields
field1 = VariableDeclaration(
    name="id",
    type_=DataType()
)

field2 = VariableDeclaration(
    name="value",
    type_=DataType()
)


# Create struct declaration
struct_def = StructDefStmt(
    name="DataPoint",
    fields=[field1, field2],
)

# Print the string representation
struct_def
print(struct_def)
```
![struct-def](https://github.com/user-attachments/assets/c601327c-2f3d-4352-af0b-6f72d341b028)

![struct_def_ipynb](https://github.com/user-attachments/assets/ab0055d9-2ad5-4004-90f2-18903970c88a)

```
struct DataPoint {
    VariableDeclaration[id, DataType]
    VariableDeclaration[value, DataType]
}
```

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [X] new feature
- [ ] maintenance

About this PR:

- [X] it includes tests.
- [X] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [X] I have reviewed the changes and it contains no misspelling.
- [X] The code is well commented, especially in the parts that contain more
      complexity.
- [X] New and old tests passed locally.

## Additional information

TO-DO:
1. add transpiler visit method
2. add transpiler tests
3. fix AST repr in jupyter notebook

Things to discuss:
1. should we do a transpiler visit method? If so, should we use `dataclass`?
2. can I get some more information on how to use dataclass for the transpiler visit method for this case?
3. AST repr in jupyter notebook

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
