### PR TITLE
feat: create `AssignmentExpr` class

### DIFF
--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -96,7 +96,7 @@ from astx.modifiers import (
     ScopeKind,
     VisibilityKind,
 )
-from astx.operators import WalrusOp
+from astx.operators import AssignmentExpr, WalrusOp
 from astx.packages import (
     AliasExpr,
     ImportExpr,
@@ -166,6 +166,7 @@ __all__ = [
     "AliasExpr",
     "Argument",
     "Arguments",
+    "AssignmentExpr",
     "BinaryOp",
     "Block",
     "Boolean",

--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -96,7 +96,7 @@ from astx.modifiers import (
     ScopeKind,
     VisibilityKind,
 )
-from astx.operators import AssignmentExpr, WalrusOp
+from astx.operators import AssignmentExpr, VariableAssignment, WalrusOp
 from astx.packages import (
     AliasExpr,
     ImportExpr,
@@ -146,7 +146,6 @@ from astx.types import (
 from astx.variables import (
     InlineVariableDeclaration,
     Variable,
-    VariableAssignment,
     VariableDeclaration,
 )
 

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -100,6 +100,7 @@ class ASTKind(Enum):
     UnaryOpKind = -300
     BinaryOpKind = -301
     WalrusOpKind = -302
+    AssignmentExprKind = -303
 
     # functions
     PrototypeKind = -400

--- a/src/astx/operators.py
+++ b/src/astx/operators.py
@@ -15,6 +15,7 @@ from astx.base import (
     Expr,
     ReprStruct,
     SourceLocation,
+    StatementType,
 )
 from astx.tools.typing import typechecked
 from astx.variables import Variable
@@ -93,4 +94,37 @@ class AssignmentExpr(Expr):
             **cast(DictDataTypesStruct, value_dict),
         }
 
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class VariableAssignment(StatementType):
+    """AST class for variable declaration."""
+
+    name: str
+    value: Expr
+
+    def __init__(
+        self,
+        name: str,
+        value: Expr,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the VarExprAST instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.loc = loc
+        self.name = name
+        self.value = value
+        self.kind = ASTKind.VariableAssignmentKind
+
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        return f"VariableAssignment[{self.name}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        key = str(self)
+        value = self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)

--- a/src/astx/operators.py
+++ b/src/astx/operators.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from typing import Iterable, Optional, cast
 
 from public import public
 
@@ -11,6 +11,7 @@ from astx.base import (
     ASTKind,
     ASTNodes,
     DataType,
+    DictDataTypesStruct,
     Expr,
     ReprStruct,
     SourceLocation,
@@ -83,6 +84,13 @@ class AssignmentExpr(Expr):
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
-        key = f"ASSIGNMENT-EXPR[{self.targets}]"
-        value = self.value.get_struct(simplified)
+        key = "ASSIGNMENT-EXPR"
+        targets_dict = {"targets": self.targets.get_struct(simplified)}
+        value_dict = {"value": self.value.get_struct(simplified)}
+
+        value = {
+            **cast(DictDataTypesStruct, targets_dict),
+            **cast(DictDataTypesStruct, value_dict),
+        }
+
         return self._prepare_struct(key, value, simplified)

--- a/src/astx/operators.py
+++ b/src/astx/operators.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from typing import Iterable, Optional
+
 from public import public
 
 from astx.base import (
     NO_SOURCE_LOCATION,
     ASTKind,
+    ASTNodes,
     DataType,
+    Expr,
     ReprStruct,
     SourceLocation,
 )
@@ -44,3 +48,41 @@ class WalrusOp(DataType):
 
         content: ReprStruct = {**lhs, **rhs}
         return self._prepare_struct(key, content, simplified)
+
+
+@public
+@typechecked
+class AssignmentExpr(Expr):
+    """AST class for assignment expressions."""
+
+    targets: ASTNodes[Expr]
+    value: Expr
+
+    def __init__(
+        self,
+        targets: Iterable[Expr] | ASTNodes[Expr],
+        value: Expr,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        super().__init__(loc=loc, parent=parent)
+
+        if isinstance(targets, ASTNodes):
+            self.targets = targets
+        else:
+            self.targets = ASTNodes()
+            for target in targets:
+                self.targets.append(target)
+
+        self.value = value
+        self.kind = ASTKind.AssignmentExprKind
+
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        return f"AssignmentExpr[{self.value}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        key = f"ASSIGNMENT-EXPR[{self.targets}]"
+        value = self.value.get_struct(simplified)
+        return self._prepare_struct(key, value, simplified)

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -63,7 +63,8 @@ class ASTxPythonTranspiler:
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.AssignmentExpr) -> str:
         """Handle AssignmentExpr nodes."""
-        return f"({self.visit(node.target)}:= {self.visit(node.value)}"
+        target_str = " = ".join(self.visit(target) for target in node.targets)
+        return f"{target_str} = {self.visit(node.value)}"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.BinaryOp) -> str:

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -61,6 +61,11 @@ class ASTxPythonTranspiler:
         return ", ".join([self.visit(arg) for arg in node.nodes])
 
     @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.AssignmentExpr) -> str:
+        """Handle AssignmentExpr nodes."""
+        return f"({self.visit(node.target)}:= {self.visit(node.value)}"
+
+    @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.BinaryOp) -> str:
         """Handle BinaryOp nodes."""
         lhs = self.visit(node.lhs)

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -413,11 +413,6 @@ class ASTxPythonTranspiler:
         return node.name
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.WalrusOp) -> str:
-        """Handle Walrus operator."""
-        return f"({self.visit(node.lhs)} := {self.visit(node.rhs)})"
-
-    @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.VariableAssignment) -> str:
         """Handle VariableAssignment nodes."""
         target = node.name
@@ -429,6 +424,11 @@ class ASTxPythonTranspiler:
         """Handle VariableDeclaration nodes."""
         value = self.visit(node.value)
         return f"{node.name}: {node.value.type_.__class__.__name__} = {value}"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.WalrusOp) -> str:
+        """Handle Walrus operator."""
+        return f"({self.visit(node.lhs)} := {self.visit(node.rhs)})"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.WhileExpr) -> str:

--- a/src/astx/variables.py
+++ b/src/astx/variables.py
@@ -64,7 +64,7 @@ class VariableDeclaration(StatementType):
         return f"VariableDeclaration[{self.name}, {type_}]"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
-        """Return a string that represents the object."""
+        """Return the AST structure of the object."""
         key = str(self)
         value = self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)
@@ -111,7 +111,7 @@ class InlineVariableDeclaration(Expr):
         return f"InlineVariableDeclaration[{self.name}, {type_}]"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
-        """Return a string that represents the object."""
+        """Return the AST structure of the object."""
         key = str(self)
         value = self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)
@@ -144,7 +144,7 @@ class VariableAssignment(StatementType):
         return f"VariableAssignment[{self.name}]"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
-        """Return a string that represents the object."""
+        """Return the AST structure of the object."""
         key = str(self)
         value = self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)
@@ -175,38 +175,7 @@ class Variable(DataTypeOps):
         return f"Variable[{self.name}]"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
-        """Return a string that represents the object."""
+        """Return the AST structure of the object."""
         key = f"Variable[{self.name}]"
         value = self.name
-        return self._prepare_struct(key, value, simplified)
-
-
-@public
-@typechecked
-class AssignmentExpr(Expr):
-    """AST class for assignment expressions."""
-
-    target: Expr
-    value: Expr
-
-    def __init__(
-        self,
-        target: Expr,
-        value: Expr,
-        loc: SourceLocation = NO_SOURCE_LOCATION,
-        parent: Optional[ASTNodes] = None,
-    ) -> None:
-        super().__init__(loc=loc, parent=parent)
-        self.target = target
-        self.value = value
-        self.kind = ASTKind.AssignmentExprKind
-
-    def __str__(self) -> str:
-        """Return a string that represents the object."""
-        return f"AssignmentExpr[{self.value}]"
-
-    def get_struct(self, simplified: bool = False) -> ReprStruct:
-        """Return the AST structure of the object."""
-        key = f"ASSIGNMENT-EXPR[{self.target}]"
-        value = self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)

--- a/src/astx/variables.py
+++ b/src/astx/variables.py
@@ -179,3 +179,34 @@ class Variable(DataTypeOps):
         key = f"Variable[{self.name}]"
         value = self.name
         return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class AssignmentExpr(Expr):
+    """AST class for assignment expressions."""
+
+    target: Expr
+    value: Expr
+
+    def __init__(
+        self,
+        target: Expr,
+        value: Expr,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        super().__init__(loc=loc, parent=parent)
+        self.target = target
+        self.value = value
+        self.kind = ASTKind.AssignmentExprKind
+
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        return f"AssignmentExpr[{self.value}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        key = f"ASSIGNMENT-EXPR[{self.target}]"
+        value = self.value.get_struct(simplified)
+        return self._prepare_struct(key, value, simplified)

--- a/src/astx/variables.py
+++ b/src/astx/variables.py
@@ -119,39 +119,6 @@ class InlineVariableDeclaration(Expr):
 
 @public
 @typechecked
-class VariableAssignment(StatementType):
-    """AST class for variable declaration."""
-
-    name: str
-    value: Expr
-
-    def __init__(
-        self,
-        name: str,
-        value: Expr,
-        loc: SourceLocation = NO_SOURCE_LOCATION,
-        parent: Optional[ASTNodes] = None,
-    ) -> None:
-        """Initialize the VarExprAST instance."""
-        super().__init__(loc=loc, parent=parent)
-        self.loc = loc
-        self.name = name
-        self.value = value
-        self.kind = ASTKind.VariableAssignmentKind
-
-    def __str__(self) -> str:
-        """Return a string that represents the object."""
-        return f"VariableAssignment[{self.name}]"
-
-    def get_struct(self, simplified: bool = False) -> ReprStruct:
-        """Return the AST structure of the object."""
-        key = str(self)
-        value = self.value.get_struct(simplified)
-        return self._prepare_struct(key, value, simplified)
-
-
-@public
-@typechecked
 class Variable(DataTypeOps):
     """AST class for the variable usage."""
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,0 +1,19 @@
+"""Tests for operators."""
+
+from astx.literals.numeric import LiteralInt32
+from astx.operators import AssignmentExpr
+from astx.variables import Variable
+from astx.viz import visualize
+
+
+def test_assignment_expr() -> None:
+    """Test `AssignmentExpr` class."""
+    var_a = Variable(name="a")
+    var_b = Variable(name="b")
+
+    assign_expr = AssignmentExpr(targets=[var_a, var_b], value=LiteralInt32(1))
+
+    assert str(assign_expr)
+    assert assign_expr.get_struct()
+    assert assign_expr.get_struct(simplified=True)
+    visualize(assign_expr.get_struct())

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,7 +1,7 @@
 """Tests for operators."""
 
 from astx.literals.numeric import LiteralInt32
-from astx.operators import AssignmentExpr
+from astx.operators import AssignmentExpr, VariableAssignment
 from astx.variables import Variable
 from astx.viz import visualize
 
@@ -17,3 +17,14 @@ def test_assignment_expr() -> None:
     assert assign_expr.get_struct()
     assert assign_expr.get_struct(simplified=True)
     visualize(assign_expr.get_struct())
+
+
+def test_variable_assign() -> None:
+    """Test function creation with modifiers."""
+    assign_a = VariableAssignment("a", value=LiteralInt32(1))
+
+    assert str(assign_a)
+    assert assign_a.get_struct()
+    assert assign_a.get_struct(simplified=True)
+
+    visualize(assign_a.get_struct())

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -42,17 +42,6 @@ def test_inline_variable_decl() -> None:
     visualize(decl_a.get_struct())
 
 
-def test_variable_assign() -> None:
-    """Test function creation with modifiers."""
-    assign_a = astx.VariableAssignment("a", value=astx.LiteralInt32(1))
-
-    assert str(assign_a)
-    assert assign_a.get_struct()
-    assert assign_a.get_struct(simplified=True)
-
-    visualize(assign_a.get_struct())
-
-
 def test_argument() -> None:
     """Test function creation with modifiers."""
     arg_a = astx.Argument(

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -1045,3 +1045,22 @@ def test_transpiler_yieldexpr_whilestmt() -> None:
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"
     )
+
+
+def test_transpiler_assignmentexpr() -> None:
+    """Test astx.AssignmentExpr."""
+    var_a = astx.Variable(name="a")
+    var_b = astx.Variable(name="b")
+
+    # create assignment expression
+    assign_expr = astx.AssignmentExpr(
+        targets=[var_a, var_b], value=astx.LiteralInt32(1)
+    )
+
+    # Generate Python code
+    generated_code = translate(assign_expr)
+    expected_code = "a = b = 1"
+
+    assert generated_code == expected_code, (
+        f"Expected '{expected_code}', but got '{generated_code}'"
+    )


### PR DESCRIPTION
## Pull Request description

This PR creates the `AssingmentExpr` class. 
This PR is an attempt to resolve #89 .

- [X] created `AssingmentExpr` class
- [X] added `AssingmentExpr` to `__init__.py`
- [X] added new ASTKind
- [X] created test for `AssingmentExpr`
- [X] added transpiler visit method for `AssingmentExpr`
- [X] added transpiler test for `AssingmentExpr`



## How to test these changes
```python
import astx

var_a = astx.Variable(name="a")
var_b = astx.Variable(name="b")

assign_expr = astx.AssignmentExpr(
    targets=[var_a, var_b],
    value=astx.LiteralInt32(1)
)
str(assign_expr)
assign_expr

from astx.tools.transpilers import python as astx2py
generator = astx2py.ASTxPythonTranspiler()
generated_code = generator.visit(assign_expr)
print(generated_code)

```
`'AssignmentExpr[LiteralInt32(1)]'`

![assign_console](https://github.com/user-attachments/assets/807d36c4-1783-4323-bdfb-5332374881d2)
![assign_ipynb](https://github.com/user-attachments/assets/2c5b4b9e-14f6-43ea-8689-6295aae8219e)

`a = b = 1`

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [X] new feature
- [ ] maintenance

About this PR:

- [X] it includes tests.
- [X] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information



```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
