### PR TITLE
feat: create `AwaitExpr` and `FunctionAsyncDef`

### DIFF
--- a/docs/tutorials/context.ipynb
+++ b/docs/tutorials/context.ipynb
@@ -138,7 +138,7 @@
     "main_block.append(astx.FunctionReturn(basic_op))\n",
     "\n",
     "# Define the main function with its body\n",
-    "main_fn = astx.Function(prototype=main_proto, body=main_block)\n",
+    "main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)\n",
     "\n",
     "# Append the main function to the module block\n",
     "module.block.append(main_fn)\n",
@@ -191,7 +191,7 @@
     "    name=\"main\", args=astx.Arguments(), return_type=astx.Int32()\n",
     ")\n",
     "# Define the main function with its body\n",
-    "main_fn = astx.Function(prototype=main_proto, body=main_block, parent=module)\n",
+    "main_fn = astx.FunctionDef(prototype=main_proto, body=main_block, parent=module)\n",
     "\n",
     "# Declare variables 'a', 'b', and 'c' with initial values\n",
     "decl_a = astx.VariableDeclaration(name=\"a\", type_=astx.Int32(), value=astx.LiteralInt32(1), parent=main_block)\n",
@@ -243,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/fibonacci.ipynb
+++ b/docs/tutorials/fibonacci.ipynb
@@ -125,7 +125,7 @@
     "fib_block = astx.Block()\n",
     "\n",
     "# Define the function with its body\n",
-    "fib_fn = astx.Function(prototype=fib_proto, body=fib_block)\n",
+    "fib_fn = astx.FunctionDef(prototype=fib_proto, body=fib_block)\n",
     "\n",
     "# Base case: if (n <= 1) return n;\n",
     "base_case_cond = astx.BinaryOp(\n",
@@ -222,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/functions.ipynb
+++ b/docs/tutorials/functions.ipynb
@@ -104,7 +104,7 @@
     "fn_math_block.append(astx.FunctionReturn(basic_op))\n",
     "\n",
     "# Define the function\n",
-    "fn_math = astx.Function(prototype=fn_math_proto, body=fn_math_block)\n",
+    "fn_math = astx.FunctionDef(prototype=fn_math_proto, body=fn_math_block)\n",
     "fn_math"
    ]
   },
@@ -184,7 +184,7 @@
     "\n",
     "\n",
     "# Define the main function\n",
-    "fn_main = astx.Function(prototype=fn_main_proto, body=fn_main_block)\n",
+    "fn_main = astx.FunctionDef(prototype=fn_main_proto, body=fn_main_block)\n",
     "\n",
     "# Append the main function to the module\n",
     "module.block.append(fn_main)\n",
@@ -222,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/get-started.ipynb
+++ b/docs/tutorials/get-started.ipynb
@@ -14,7 +14,7 @@
     "Many kinds of nodes (classes) are currently supported. Below is a list with just some examples:\n",
     "\n",
     "##### Statements:\n",
-    "* Function\n",
+    "* FunctionDef\n",
     "* Function Prototype\n",
     "* FunctionReturn\n",
     "* ForRangeLoop \n",
@@ -113,7 +113,7 @@
    "id": "84c6d62e-253d-4e93-aa54-998aa1889ce1",
    "metadata": {},
    "source": [
-    "After the basic expression is stated, we create an instance of the Function class. As mentioned in the API documentation, each instance of the Function class must have a prototype and a body, so we'll create those first.\n",
+    "After the basic expression is stated, we create an instance of the FunctionDef class. As mentioned in the API documentation, each instance of the FunctionDef class must have a prototype and a body, so we'll create those first.\n",
     "\n",
     "The body is made of a block that is created and the variables, as well as the basic operation, are appended to it afterwards."
    ]
@@ -138,7 +138,7 @@
     "main_block.append(astx.FunctionReturn(basic_op))\n",
     "\n",
     "# Create Function\n",
-    "main_fn = astx.Function(prototype=main_proto, body=main_block)\n",
+    "main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)\n",
     "\n",
     "# Append function to module\n",
     "module.block.append(main_fn)"
@@ -514,7 +514,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/variables.ipynb
+++ b/docs/tutorials/variables.ipynb
@@ -140,7 +140,7 @@
     "main_block.append(astx.FunctionReturn(basic_op))\n",
     "\n",
     "# Define the main function with its body\n",
-    "main_fn = astx.Function(prototype=main_proto, body=main_block)\n",
+    "main_fn = astx.FunctionDef(prototype=main_proto, body=main_block)\n",
     "\n",
     "# Append the main function to the module block\n",
     "module.block.append(main_fn)\n",
@@ -178,7 +178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -35,11 +35,14 @@ from astx.blocks import (
 from astx.callables import (
     Argument,
     Arguments,
-    Function,
+    AwaitExpr,
+    FunctionAsyncDef,
     FunctionCall,
+    FunctionDef,
     FunctionPrototype,
     FunctionReturn,
     LambdaExpr,
+    YieldExpr,
 )
 from astx.classes import (
     ClassDeclStmt,
@@ -66,7 +69,6 @@ from astx.flows import (
     SwitchStmt,
     WhileExpr,
     WhileStmt,
-    YieldExpr,
 )
 from astx.literals import (
     Literal,
@@ -188,6 +190,7 @@ __all__ = [
     "Argument",
     "Arguments",
     "AssignmentExpr",
+    "AwaitExpr",
     "BinaryOp",
     "Block",
     "BoolBinaryOp",
@@ -217,8 +220,9 @@ __all__ = [
     "ForCountLoopStmt",
     "ForRangeLoopExpr",
     "ForRangeLoopStmt",
-    "Function",
+    "FunctionAsyncDef",
     "FunctionCall",
+    "FunctionDef",
     "FunctionPrototype",
     "FunctionReturn",
     "GotoStmt",

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -106,10 +106,13 @@ class ASTKind(Enum):
 
     # functions
     PrototypeKind = -400
-    FunctionKind = -401
+    FunctionDefKind = -401
     CallKind = -402
     ReturnKind = -403
     LambdaExprKind = -404
+    FunctionAsyncDefKind = -405
+    AwaitExprKind = -406
+    YieldExprKind = -510
 
     # control flow
     IfStmtKind = -500
@@ -122,7 +125,6 @@ class ASTKind(Enum):
     IfExprKind = -507
     CaseStmtKind = -508
     SwitchStmtKind = -509
-    YieldExprKind = -510
     GotoStmtKind = -511
 
     # data types

--- a/src/astx/callables.py
+++ b/src/astx/callables.py
@@ -311,28 +311,11 @@ class FunctionAsyncDef(FunctionDef):
         super().__init__(
             loc=loc, parent=parent, body=body, prototype=prototype
         )
-        # super().__init__(loc=loc, parent=parent)
-        # self.prototype = prototype
-        # self.body = body
         self.kind = ASTKind.FunctionAsyncDefKind
-
-    # @property # I think this is fine inherited from FunctionDef
-    # def name(self) -> str:
-    #     """Return the function prototype name."""
-    #     return self.prototype.name
 
     def __str__(self) -> str:
         """Return a string that represent the object."""
         return f"FunctionAsyncDef[{self.name}]"
-
-    # def __call__( # I think this is fine inherited from FunctionDef
-    #     self,
-    #     args: tuple[DataType, ...],
-    #     loc: SourceLocation = NO_SOURCE_LOCATION,
-    #     parent: Optional[ASTNodes] = None,
-    # ) -> FunctionCall:
-    #     """Initialize the Call instance."""
-    #     return FunctionCall(fn=self, args=args, loc=loc, parent=parent)
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Get the AST structure that represent the object."""

--- a/src/astx/callables.py
+++ b/src/astx/callables.py
@@ -95,13 +95,13 @@ class Arguments(ASTNodes[Argument]):
 class FunctionCall(DataType):
     """AST class for function call."""
 
-    fn: Function
+    fn: FunctionDef
     args: Iterable[DataType]
     type_: DataType = AnyType()
 
     def __init__(
         self,
-        fn: Function,
+        fn: FunctionDef,
         args: Iterable[DataType],
         type_: DataType = AnyType(),
         loc: SourceLocation = NO_SOURCE_LOCATION,
@@ -207,7 +207,7 @@ class FunctionReturn(StatementType):
 
 @public
 @typechecked
-class Function(StatementType):
+class FunctionDef(StatementType):
     """AST class for function definition."""
 
     prototype: FunctionPrototype
@@ -224,7 +224,7 @@ class Function(StatementType):
         super().__init__(loc=loc, parent=parent)
         self.prototype = prototype
         self.body = body
-        self.kind = ASTKind.FunctionKind
+        self.kind = ASTKind.FunctionDefKind
 
     @property
     def name(self) -> str:
@@ -233,7 +233,7 @@ class Function(StatementType):
 
     def __str__(self) -> str:
         """Return a string that represent the object."""
-        return f"Function[{self.name}]"
+        return f"FunctionDef[{self.name}]"
 
     def __call__(
         self,
@@ -249,7 +249,7 @@ class Function(StatementType):
         fn_args = self.prototype.args.get_struct(simplified)
         fn_body = self.body.get_struct(simplified)
 
-        key = f"FUNCTION[{self.prototype.name}]"
+        key = f"FUNCTION-DEF[{self.prototype.name}]"
         args_struct = {"args": fn_args}
         body_struct = {"body": fn_body}
 
@@ -289,4 +289,117 @@ class LambdaExpr(Expr):
             "params": self.params.get_struct(simplified),
             "body": self.body.get_struct(simplified),
         }
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class FunctionAsyncDef(FunctionDef):
+    """AST class for async function definition."""
+
+    prototype: FunctionPrototype
+    body: Block
+
+    def __init__(
+        self,
+        prototype: FunctionPrototype,
+        body: Block,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the FunctionAsync instance."""
+        super().__init__(
+            loc=loc, parent=parent, body=body, prototype=prototype
+        )
+        # super().__init__(loc=loc, parent=parent)
+        # self.prototype = prototype
+        # self.body = body
+        self.kind = ASTKind.FunctionAsyncDefKind
+
+    # @property # I think this is fine inherited from FunctionDef
+    # def name(self) -> str:
+    #     """Return the function prototype name."""
+    #     return self.prototype.name
+
+    def __str__(self) -> str:
+        """Return a string that represent the object."""
+        return f"FunctionAsyncDef[{self.name}]"
+
+    # def __call__( # I think this is fine inherited from FunctionDef
+    #     self,
+    #     args: tuple[DataType, ...],
+    #     loc: SourceLocation = NO_SOURCE_LOCATION,
+    #     parent: Optional[ASTNodes] = None,
+    # ) -> FunctionCall:
+    #     """Initialize the Call instance."""
+    #     return FunctionCall(fn=self, args=args, loc=loc, parent=parent)
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Get the AST structure that represent the object."""
+        fn_args = self.prototype.args.get_struct(simplified)
+        fn_body = self.body.get_struct(simplified)
+
+        key = f"FUNCTIONASYNC-DEF[{self.prototype.name}]"
+        args_struct = {"args": fn_args}
+        body_struct = {"body": fn_body}
+
+        value: ReprStruct = {**args_struct, **body_struct}
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class AwaitExpr(Expr):
+    """AST class for AwaitExpr."""
+
+    value: Optional[Expr]
+
+    def __init__(
+        self,
+        value: Optional[Expr],
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the AwaitExpr instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.value = value
+        self.kind = ASTKind.AwaitExprKind
+
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        return f"AwaitExpr[{self.value}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        key = "AWAIT-EXPR"
+        value = {} if self.value is None else self.value.get_struct(simplified)
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class YieldExpr(Expr):
+    """AST class for YieldExpr."""
+
+    value: Optional[Expr]
+
+    def __init__(
+        self,
+        value: Optional[Expr],
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the YieldExpr instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.value = value
+        self.kind = ASTKind.YieldExprKind
+
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        return f"YieldExpr[{self.value}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        key = "YIELD-EXPR"
+        value = {} if self.value is None else self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)

--- a/src/astx/classes.py
+++ b/src/astx/classes.py
@@ -19,7 +19,7 @@ from astx.base import (
     StatementType,
 )
 from astx.blocks import Block
-from astx.callables import Function
+from astx.callables import FunctionDef
 from astx.modifiers import VisibilityKind
 from astx.tools.typing import typechecked
 from astx.variables import VariableDeclaration
@@ -37,7 +37,7 @@ class ClassDeclStmt(StatementType):
     is_abstract: bool
     metaclass: Optional[Expr]
     attributes: ASTNodes[VariableDeclaration]
-    methods: ASTNodes[Function]
+    methods: ASTNodes[FunctionDef]
 
     def __init__(
         self,
@@ -49,7 +49,7 @@ class ClassDeclStmt(StatementType):
         metaclass: Optional[Expr] = None,
         attributes: Iterable[VariableDeclaration]
         | ASTNodes[VariableDeclaration] = [],
-        methods: Iterable[Function] | ASTNodes[Function] = [],
+        methods: Iterable[FunctionDef] | ASTNodes[FunctionDef] = [],
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
     ) -> None:
@@ -81,7 +81,7 @@ class ClassDeclStmt(StatementType):
         if isinstance(methods, ASTNodes):
             self.methods = methods
         else:
-            self.methods = ASTNodes[Function]()
+            self.methods = ASTNodes[FunctionDef]()
             for m in methods:
                 self.methods.append(m)
 
@@ -181,7 +181,7 @@ class ClassDefStmt(ClassDeclStmt):
         metaclass: Optional[Expr] = None,
         attributes: Iterable[VariableDeclaration]
         | ASTNodes[VariableDeclaration] = [],
-        methods: Iterable[Function] | ASTNodes[Function] = [],
+        methods: Iterable[FunctionDef] | ASTNodes[FunctionDef] = [],
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
     ) -> None:
@@ -297,7 +297,7 @@ class StructDeclStmt(StatementType):
     attributes: ASTNodes[VariableDeclaration]
     visibility: VisibilityKind
     decorators: ASTNodes[Expr]
-    methods: ASTNodes[Function]
+    methods: ASTNodes[FunctionDef]
 
     def __init__(
         self,
@@ -305,7 +305,7 @@ class StructDeclStmt(StatementType):
         attributes: Iterable[VariableDeclaration]
         | ASTNodes[VariableDeclaration] = [],
         decorators: Iterable[Expr] | ASTNodes[Expr] = [],
-        methods: Iterable[Function] | ASTNodes[Function] = [],
+        methods: Iterable[FunctionDef] | ASTNodes[FunctionDef] = [],
         visibility: VisibilityKind = VisibilityKind.public,
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
@@ -331,7 +331,7 @@ class StructDeclStmt(StatementType):
         if isinstance(methods, ASTNodes):
             self.methods = methods
         else:
-            self.methods = ASTNodes[Function]()
+            self.methods = ASTNodes[FunctionDef]()
             for m in methods:
                 self.methods.append(m)
 
@@ -391,7 +391,7 @@ class StructDefStmt(StructDeclStmt):
         attributes: Iterable[VariableDeclaration]
         | ASTNodes[VariableDeclaration] = [],
         decorators: Iterable[Expr] | ASTNodes[Expr] = [],
-        methods: Iterable[Function] | ASTNodes[Function] = [],
+        methods: Iterable[FunctionDef] | ASTNodes[FunctionDef] = [],
         visibility: VisibilityKind = VisibilityKind.public,
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,

--- a/src/astx/flows.py
+++ b/src/astx/flows.py
@@ -537,35 +537,6 @@ class SwitchStmt(StatementType):
 
 @public
 @typechecked
-class YieldExpr(Expr):
-    """AST class for YieldExpr."""
-
-    value: Optional[Expr]
-
-    def __init__(
-        self,
-        value: Optional[Expr],
-        loc: SourceLocation = NO_SOURCE_LOCATION,
-        parent: Optional[ASTNodes] = None,
-    ) -> None:
-        """Initialize the YieldExpr instance."""
-        super().__init__(loc=loc, parent=parent)
-        self.value = value
-        self.kind = ASTKind.YieldExprKind
-
-    def __str__(self) -> str:
-        """Return a string representation of the object."""
-        return f"YieldExpr[{self.value}]"
-
-    def get_struct(self, simplified: bool = False) -> ReprStruct:
-        """Return the AST structure of the object."""
-        key = "YIELD-EXPR"
-        value = {} if self.value is None else self.value.get_struct(simplified)
-        return self._prepare_struct(key, value, simplified)
-
-
-@public
-@typechecked
 class GotoStmt(StatementType):
     """AST class for function `Goto` statement."""
 

--- a/src/astx/mixes.py
+++ b/src/astx/mixes.py
@@ -8,9 +8,9 @@ except ImportError:
     from typing_extensions import TypeAlias
 
 from astx.base import DataType
-from astx.callables import Function
+from astx.callables import FunctionDef
 from astx.variables import Variable
 
 __all__ = ["NamedExpr"]
 
-NamedExpr: TypeAlias = Union[DataType, Function, Variable]
+NamedExpr: TypeAlias = Union[DataType, FunctionDef, Variable]

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -67,6 +67,12 @@ class ASTxPythonTranspiler:
         return f"{target_str} = {self.visit(node.value)}"
 
     @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.AwaitExpr) -> str:
+        """Handle AwaitExpr nodes."""
+        value = self.visit(node.value) if node.value else ""
+        return f"await {value}".strip()
+
+    @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.BinaryOp) -> str:
         """Handle BinaryOp nodes."""
         lhs = self.visit(node.lhs)
@@ -147,8 +153,21 @@ class ASTxPythonTranspiler:
         )
 
     @dispatch  # type: ignore[no-redef]
-    def visit(self, node: astx.Function) -> str:
-        """Handle Function nodes."""
+    def visit(self, node: astx.FunctionAsyncDef) -> str:
+        """Handle FunctionAsyncDef nodes."""
+        args = self.visit(node.prototype.args)
+        returns = (
+            f" -> {self.visit(node.prototype.return_type)}"
+            if node.prototype.return_type
+            else ""
+        )
+        header = f"async def {node.name}({args}){returns}:"
+        body = self.visit(node.body)
+        return f"{header}\n{body}"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.FunctionDef) -> str:
+        """Handle FunctionDef nodes."""
         args = self.visit(node.prototype.args)
         returns = (
             f" -> {self.visit(node.prototype.return_type)}"

--- a/tests/examples/test_fibonacci.py
+++ b/tests/examples/test_fibonacci.py
@@ -77,7 +77,7 @@ def test_function_call_fibonacci() -> None:
     fib_block.append(return_stmt)
 
     # Define the function with its body
-    fib_fn = astx.Function(prototype=fib_proto, body=fib_block)
+    fib_fn = astx.FunctionDef(prototype=fib_proto, body=fib_block)
 
     # Append the Fibonacci function to the module block
     module.block.append(fib_fn)

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -6,11 +6,14 @@ from astx.blocks import Block
 from astx.callables import (
     Argument,
     Arguments,
-    Function,
+    AwaitExpr,
+    FunctionAsyncDef,
     FunctionCall,
+    FunctionDef,
     FunctionPrototype,
     FunctionReturn,
     LambdaExpr,
+    YieldExpr,
 )
 from astx.literals.numeric import LiteralInt32
 from astx.modifiers import ScopeKind, VisibilityKind
@@ -20,7 +23,7 @@ from astx.variables import Variable
 from astx.viz import visualize
 
 
-def test_function_creation_with_no_modifiers() -> None:
+def test_functiondef_creation_with_no_modifiers() -> None:
     """Test function creation with no modifiers."""
     var_a = Argument("a", type_=Int32(), default=LiteralInt32(1))
     var_b = Argument("b", type_=Int32(), default=LiteralInt32(1))
@@ -35,7 +38,7 @@ def test_function_creation_with_no_modifiers() -> None:
         proto.get_struct()
 
     fn_block = Block()
-    fn = Function(prototype=proto, body=fn_block)
+    fn = FunctionDef(prototype=proto, body=fn_block)
 
     assert str(fn)
     assert fn.get_struct()
@@ -44,7 +47,7 @@ def test_function_creation_with_no_modifiers() -> None:
     visualize(fn.get_struct())
 
 
-def test_function_creation_with_modifiers() -> None:
+def test_functiondef_creation_with_modifiers() -> None:
     """Test function creation with modifiers."""
     var_a = Argument("a", type_=Int32(), default=LiteralInt32(1))
     var_b = Argument("b", type_=Int32(), default=LiteralInt32(1))
@@ -56,7 +59,7 @@ def test_function_creation_with_modifiers() -> None:
         scope=ScopeKind.global_,
     )
     fn_block = Block()
-    fn = Function(prototype=proto, body=fn_block)
+    fn = FunctionDef(prototype=proto, body=fn_block)
 
     assert str(fn)
     assert fn.get_struct()
@@ -77,7 +80,7 @@ def test_function_call() -> None:
         scope=ScopeKind.global_,
     )
     fn_block = Block()
-    fn = Function(prototype=proto, body=fn_block)
+    fn = FunctionDef(prototype=proto, body=fn_block)
 
     lit_int32_1 = LiteralInt32(1)
 
@@ -116,3 +119,47 @@ def test_lambdaexpr_noparams() -> None:
     assert str(lambda_expr)
     assert lambda_expr.get_struct()
     assert lambda_expr.get_struct(simplified=True)
+
+
+def test_functionasync_creation_with_no_modifiers() -> None:
+    """Test async function creation with no modifiers."""
+    var_a = Argument("a", type_=Int32(), default=LiteralInt32(1))
+    var_b = Argument("b", type_=Int32(), default=LiteralInt32(1))
+
+    proto = FunctionPrototype(
+        name="add",
+        args=Arguments(var_a, var_b),
+        return_type=Int32(),
+    )
+
+    with pytest.raises(Exception):
+        proto.get_struct()
+
+    fn_block = Block()
+    fn = FunctionAsyncDef(prototype=proto, body=fn_block)
+
+    assert str(fn)
+    assert fn.get_struct()
+    assert fn.get_struct(simplified=True)
+
+    visualize(fn.get_struct())
+
+
+def test_await_expr() -> None:
+    """Test `AwaitExpr` class."""
+    await_expr = AwaitExpr(value=LiteralInt32(1))
+
+    assert str(await_expr)
+    assert await_expr.get_struct()
+    assert await_expr.get_struct(simplified=True)
+    visualize(await_expr.get_struct())
+
+
+def test_yield_expr() -> None:
+    """Test `YieldExpr` class."""
+    yield_expr = YieldExpr(value=LiteralInt32(1))
+
+    assert str(yield_expr)
+    assert yield_expr.get_struct()
+    assert yield_expr.get_struct(simplified=True)
+    visualize(yield_expr.get_struct())

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -2,7 +2,7 @@
 
 from astx.base import DataType
 from astx.blocks import Block
-from astx.callables import Arguments, Function, FunctionPrototype
+from astx.callables import Arguments, FunctionDef, FunctionPrototype
 from astx.classes import (
     ClassDeclStmt,
     ClassDefStmt,
@@ -50,7 +50,7 @@ def test_class_def() -> None:
         return_type=AnyType(),
     )
 
-    method = Function(
+    method = FunctionDef(
         prototype=prototype,
         body=Block(),
     )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,8 +5,8 @@ from astx.blocks import Block
 from astx.callables import (
     Argument,
     Arguments,
-    Function,
     FunctionCall,
+    FunctionDef,
     FunctionPrototype,
 )
 from astx.exceptions import (
@@ -43,7 +43,7 @@ def fn_print(
         args=Arguments(Argument("_", type_=String())),
         return_type=String(),
     )
-    fn = Function(prototype=proto, body=Block())
+    fn = FunctionDef(prototype=proto, body=Block())
     return FunctionCall(
         fn=fn,
         args=[arg],

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -273,16 +273,6 @@ def test_switch_stmt() -> None:
     visualize(switch_stmt.get_struct())
 
 
-def test_yield_expr() -> None:
-    """Test `YieldExpr` class."""
-    yield_expr = astx.YieldExpr(value=LiteralInt32(1))
-
-    assert str(yield_expr)
-    assert yield_expr.get_struct()
-    assert yield_expr.get_struct(simplified=True)
-    visualize(yield_expr.get_struct())
-
-
 def test_goto_stmt() -> None:
     """Test `GotoStmt` class."""
     goto_stmt = astx.GotoStmt(astx.Identifier("label1"))

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -1254,14 +1254,15 @@ def test_group_expr() -> None:
 
 def test_transpiler_functionasyncdef() -> None:
     """Test astx.FunctionAsyncDef."""
-    var_a = astx.Argument(
+    arg_a = astx.Argument(
         "a", type_=astx.Int32(), default=astx.LiteralInt32(1)
     )
     proto = astx.FunctionPrototype(
         name="aget",
-        args=astx.Arguments(var_a),
+        args=astx.Arguments(arg_a),
         return_type=astx.Int32(),
     )
+    var_a = astx.Variable("a")
 
     return_stmt = astx.FunctionReturn(value=var_a)
 
@@ -1272,7 +1273,7 @@ def test_transpiler_functionasyncdef() -> None:
 
     # Generate Python code
     generated_code = translate(fn_a)
-    expected_code = "async def aget(a: int) -> int:\n    return a: int"
+    expected_code = "async def aget(a: int) -> int:\n    return a"
 
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"
@@ -1281,14 +1282,12 @@ def test_transpiler_functionasyncdef() -> None:
 
 def test_transpiler_await_expr_() -> None:
     """Test astx.AwaitExpr."""
-    var_a = astx.Argument(
-        "a", type_=astx.Int32(), default=astx.LiteralInt32(1)
-    )
+    var_a = astx.Variable("a")
     await_expr = astx.AwaitExpr(value=var_a)
 
     # Generate Python code
     generated_code = translate(await_expr)
-    expected_code = "await a: int"
+    expected_code = "await a"
 
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -209,8 +209,8 @@ def test_transpiler_lambdaexpr_noparams() -> None:
     assert generated_code == expected_code, "generated_code != expected_code"
 
 
-def test_transpiler_function() -> None:
-    """Test astx.Function."""
+def test_transpiler_functiondef() -> None:
+    """Test astx.FunctionDef."""
     # Function parameters
     args = astx.Arguments(
         astx.Argument(name="x", type_=astx.Int32()),
@@ -239,7 +239,7 @@ def test_transpiler_function() -> None:
     )
 
     # Function definition
-    add_function = astx.Function(
+    add_function = astx.FunctionDef(
         prototype=astx.FunctionPrototype(
             name="add",
             args=args,
@@ -967,7 +967,7 @@ def fn_print(
         args=astx.Arguments(astx.Argument("_", type_=astx.String())),
         return_type=astx.String(),
     )
-    fn = astx.Function(prototype=proto, body=astx.Block())
+    fn = astx.FunctionDef(prototype=proto, body=astx.Block())
     return astx.FunctionCall(
         fn=fn,
         args=[arg],

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -1163,6 +1163,33 @@ def test_transpiler_and_op() -> None:
     generated_code = translate(op)
 
     expected_code = "x and y"
+
+    assert generated_code == expected_code, (
+        f"Expected '{expected_code}', but got '{generated_code}'"
+    )
+
+def test_transpiler_functionasyncdef() -> None:
+    """Test astx.FunctionAsyncDef."""
+    var_a = astx.Argument(
+        "a", type_=astx.Int32(), default=astx.LiteralInt32(1)
+    )
+    proto = astx.FunctionPrototype(
+        name="aget",
+        args=astx.Arguments(var_a),
+        return_type=astx.Int32(),
+    )
+
+    return_stmt = astx.FunctionReturn(value=var_a)
+
+    fn_block = astx.Block()
+    fn_block.append(return_stmt)
+
+    fn_a = astx.FunctionAsyncDef(prototype=proto, body=fn_block)
+
+    # Generate Python code
+    generated_code = translate(fn_a)
+    expected_code = "async def aget(a: int) -> int:\n    return a: int"
+
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"
     )
@@ -1245,6 +1272,23 @@ def test_group_expr() -> None:
     )
     generated_code = translate(grp)
     expected_code = "(True and False)"
+
+    assert generated_code == expected_code, (
+        f"Expected '{expected_code}', but got '{generated_code}'"
+    )
+
+
+def test_transpiler_await_expr_() -> None:
+    """Test astx.AwaitExpr."""
+    var_a = astx.Argument(
+        "a", type_=astx.Int32(), default=astx.LiteralInt32(1)
+    )
+    await_expr = astx.AwaitExpr(value=var_a)
+
+    # Generate Python code
+    generated_code = translate(await_expr)
+    expected_code = "await a: int"
+
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"
     )

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -1168,32 +1168,6 @@ def test_transpiler_and_op() -> None:
         f"Expected '{expected_code}', but got '{generated_code}'"
     )
 
-def test_transpiler_functionasyncdef() -> None:
-    """Test astx.FunctionAsyncDef."""
-    var_a = astx.Argument(
-        "a", type_=astx.Int32(), default=astx.LiteralInt32(1)
-    )
-    proto = astx.FunctionPrototype(
-        name="aget",
-        args=astx.Arguments(var_a),
-        return_type=astx.Int32(),
-    )
-
-    return_stmt = astx.FunctionReturn(value=var_a)
-
-    fn_block = astx.Block()
-    fn_block.append(return_stmt)
-
-    fn_a = astx.FunctionAsyncDef(prototype=proto, body=fn_block)
-
-    # Generate Python code
-    generated_code = translate(fn_a)
-    expected_code = "async def aget(a: int) -> int:\n    return a: int"
-
-    assert generated_code == expected_code, (
-        f"Expected '{expected_code}', but got '{generated_code}'"
-    )
-
 
 def test_transpiler_or_op() -> None:
     """Test transpiler for OrOp."""
@@ -1272,6 +1246,33 @@ def test_group_expr() -> None:
     )
     generated_code = translate(grp)
     expected_code = "(True and False)"
+
+    assert generated_code == expected_code, (
+        f"Expected '{expected_code}', but got '{generated_code}'"
+    )
+
+
+def test_transpiler_functionasyncdef() -> None:
+    """Test astx.FunctionAsyncDef."""
+    var_a = astx.Argument(
+        "a", type_=astx.Int32(), default=astx.LiteralInt32(1)
+    )
+    proto = astx.FunctionPrototype(
+        name="aget",
+        args=astx.Arguments(var_a),
+        return_type=astx.Int32(),
+    )
+
+    return_stmt = astx.FunctionReturn(value=var_a)
+
+    fn_block = astx.Block()
+    fn_block.append(return_stmt)
+
+    fn_a = astx.FunctionAsyncDef(prototype=proto, body=fn_block)
+
+    # Generate Python code
+    generated_code = translate(fn_a)
+    expected_code = "async def aget(a: int) -> int:\n    return a: int"
 
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"


### PR DESCRIPTION
## Pull Request description

This PR creates the `AwaitExpr` and `FunctionAsyncDef` classes. 
This PR is an attempt to resolve #108  .

- [X] changed `Function` class to `FunctionDef`
- [X] moved `YieldExpr` from `flows` to `callables`.
- [X] created `AwaitExpr` and `FunctionAsyncDef` classes. 
- [X] added `AwaitExpr` and `FunctionAsyncDef` to `__init__.py`
- [X] added new ASTKind's
- [X] created tests for `AwaitExpr` and `FunctionAsyncDef`
- [X] added transpiler visit method for `AwaitExpr` and `FunctionAsyncDef`
- [ ] added transpiler tests for `AwaitExpr` and `FunctionAsyncDef` (added but currently not working)

## How to test these changes
```python
from astx.callables import AwaitExpr
from astx.blocks import Block
from astx.callables import (
    Argument,
    Arguments,
    FunctionPrototype,
    FunctionAsyncDef,
    FunctionReturn,
)
from astx.literals.numeric import LiteralInt32
from astx.types.numeric import Int32


var_a = Argument("a", type_=Int32(), default=LiteralInt32(1))
proto = FunctionPrototype(
    name="aget",
    args=Arguments(var_a),
    return_type=Int32(),
)

return_stmt = FunctionReturn(value=var_a)

fn_block = Block()
fn_block.append(return_stmt)

fn = FunctionAsyncDef(prototype=proto, body=fn_block)
fn

var_a = Argument("a", type_=Int32(), default=LiteralInt32(1))
await_expr = AwaitExpr(value=var_a)
await_expr

from astx.tools.transpilers import python as astx2py
generator = astx2py.ASTxPythonTranspiler()
generated_code1 = generator.visit(fn)
print(generated_code1)

generated_code2 = generator.visit(await_expr)
print(generated_code2)

```
Outputs:
![astx_console_functionasync_def](https://github.com/user-attachments/assets/22eefc77-d30a-44dc-848d-d3cc1b1c8af4)
![functionasyncdef_ipynb](https://github.com/user-attachments/assets/d7d120e7-23eb-4e72-ba68-7263440e18dd)
![await_console](https://github.com/user-attachments/assets/c36e7241-cad6-471f-a48c-431d99721860)
![await_ipynb](https://github.com/user-attachments/assets/d44878de-afa8-4111-9029-9e9ba5320870)

```
async def aget(a: int) -> int:
    return a: int
```
`await a: int`

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [X] new feature
- [ ] maintenance

About this PR:

- [X] it includes tests.
- [X] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information


## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
