### PR TITLE
feat: Add support for `YieldFromExpr`

### DIFF
--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -43,6 +43,7 @@ from astx.callables import (
     FunctionReturn,
     LambdaExpr,
     YieldExpr,
+    YieldFromExpr,
 )
 from astx.classes import (
     ClassDeclStmt,
@@ -330,6 +331,7 @@ __all__ = [
     "XnorOp",
     "XorOp",
     "YieldExpr",
+    "YieldFromExpr",
     "base",
     "blocks",
     "callables",

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -113,6 +113,7 @@ class ASTKind(Enum):
     FunctionAsyncDefKind = -405
     AwaitExprKind = -406
     YieldExprKind = -510
+    YieldFromExprKind = -1207
 
     # control flow
     IfStmtKind = -500

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -113,7 +113,7 @@ class ASTKind(Enum):
     FunctionAsyncDefKind = -405
     AwaitExprKind = -406
     YieldExprKind = -510
-    YieldFromExprKind = -1207
+    YieldFromExprKind = -407
 
     # control flow
     IfStmtKind = -500

--- a/src/astx/callables.py
+++ b/src/astx/callables.py
@@ -386,3 +386,32 @@ class YieldExpr(Expr):
         key = "YIELD-EXPR"
         value = {} if self.value is None else self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class YieldFromExpr(Expr):
+    """AST class for YieldFromExpr."""
+
+    value: Optional[Expr]
+
+    def __init__(
+        self,
+        value: Optional[Expr],
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the YieldFromExpr instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.value = value
+        self.kind = ASTKind.YieldFromExprKind
+
+    def __str__(self) -> str:
+        """Return a string representation of the object."""
+        return f"YieldFromExpr[{self.value}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        key = "YIELDFROM-EXPR"
+        value = {} if self.value is None else self.value.get_struct(simplified)
+        return self._prepare_struct(key, value, simplified)

--- a/src/astx/callables.py
+++ b/src/astx/callables.py
@@ -393,11 +393,11 @@ class YieldExpr(Expr):
 class YieldFromExpr(Expr):
     """AST class for YieldFromExpr."""
 
-    value: Optional[Expr]
+    value: Expr
 
     def __init__(
         self,
-        value: Optional[Expr],
+        value: Expr,
         loc: SourceLocation = NO_SOURCE_LOCATION,
         parent: Optional[ASTNodes] = None,
     ) -> None:
@@ -413,5 +413,5 @@ class YieldFromExpr(Expr):
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
         key = "YIELDFROM-EXPR"
-        value = {} if self.value is None else self.value.get_struct(simplified)
+        value = self.value.get_struct(simplified)
         return self._prepare_struct(key, value, simplified)

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -520,7 +520,7 @@ class ASTxPythonTranspiler:
         value = self.visit(node.value) if node.value else ""
         return f"yield {value}".strip()
 
-      @dispatch  # type: ignore[no-redef]
+    @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.YieldFromExpr) -> str:
         """Handle YieldFromExpr nodes."""
         value = self.visit(node.value)

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -520,6 +520,12 @@ class ASTxPythonTranspiler:
         value = self.visit(node.value) if node.value else ""
         return f"yield {value}".strip()
 
+      @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.YieldFromExpr) -> str:
+        """Handle YieldFromExpr nodes."""
+        value = self.visit(node.value)
+        return f"yield from {value}".strip()
+
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.Date) -> str:
         """Handle Date nodes."""

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -165,6 +165,7 @@ def test_yield_expr() -> None:
     assert yield_expr.get_struct(simplified=True)
     visualize(yield_expr.get_struct())
 
+
 def test_yieldfrom_expr() -> None:
     """Test `YieldFromExpr` class."""
     yieldfrom_expr = YieldFromExpr(value=LiteralInt32(1))

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -14,6 +14,7 @@ from astx.callables import (
     FunctionReturn,
     LambdaExpr,
     YieldExpr,
+    YieldFromExpr,
 )
 from astx.literals.numeric import LiteralInt32
 from astx.modifiers import ScopeKind, VisibilityKind
@@ -163,3 +164,12 @@ def test_yield_expr() -> None:
     assert yield_expr.get_struct()
     assert yield_expr.get_struct(simplified=True)
     visualize(yield_expr.get_struct())
+
+def test_yieldfrom_expr() -> None:
+    """Test `YieldFromExpr` class."""
+    yieldfrom_expr = YieldFromExpr(value=LiteralInt32(1))
+
+    assert str(yieldfrom_expr)
+    assert yieldfrom_expr.get_struct()
+    assert yieldfrom_expr.get_struct(simplified=True)
+    visualize(yieldfrom_expr.get_struct())

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -1047,6 +1047,33 @@ def test_transpiler_yieldexpr_whilestmt() -> None:
     )
 
 
+def test_transpiler_yieldfromexpr_whilestmt() -> None:
+    """Test astx.YieldFromExpr (using WhileStmt)."""
+    # Create the `while True` loop
+    while_cond = astx.LiteralBoolean(True)
+    while_body = astx.Block()
+
+    # Create the `yield` expression
+    yieldfrom_expr = astx.YieldFromExpr(value=astx.LiteralList([astx.LiteralInt32(1), astx.LiteralInt32(2)]))
+
+    # Assign the result of `yield` back to `value`
+    assign_value = astx.VariableAssignment(name="value", value=yieldfrom_expr)
+
+    # Add the assignment to the loop body
+    while_body.append(assign_value)
+
+    # Define the `while` loop and add it to the function body
+    while_stmt = astx.WhileStmt(condition=while_cond, body=while_body)
+
+    # Generate Python code
+    generated_code = translate(while_stmt)
+    expected_code = "while True:\n    value = yield from [1, 2]"
+
+    assert generated_code == expected_code, (
+        f"Expected '{expected_code}', but got '{generated_code}'"
+    )
+
+
 def test_transpiler_assignmentexpr() -> None:
     """Test astx.AssignmentExpr."""
     var_a = astx.Variable(name="a")

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -1054,9 +1054,7 @@ def test_transpiler_yieldfromexpr_whilestmt() -> None:
     while_body = astx.Block()
 
     # Create the `yieldfrom` expression
-    yieldfrom_expr = astx.YieldFromExpr(
-        value=astx.LiteralList([astx.LiteralInt32(1), astx.LiteralInt32(2)])
-    )
+    yieldfrom_expr = astx.YieldFromExpr(value=astx.LiteralInt32(1))
 
     # Assign the result of `yieldfrom` back to `value`
     assign_value = astx.VariableAssignment(name="value", value=yieldfrom_expr)
@@ -1069,7 +1067,7 @@ def test_transpiler_yieldfromexpr_whilestmt() -> None:
 
     # Generate Python code
     generated_code = translate(while_stmt)
-    expected_code = "while True:\n    value = yield from [1, 2]"
+    expected_code = "while True:\n    value = yield from 1"
 
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -1054,7 +1054,7 @@ def test_transpiler_yieldfromexpr_whilestmt() -> None:
     while_body = astx.Block()
 
     # Create the `yieldfrom` expression
-    yieldfrom_expr = astx.YieldFromExpr(value=astx.LiteralInt32(1))
+    yieldfrom_expr = astx.YieldFromExpr(value=astx.Variable("x"))
 
     # Assign the result of `yieldfrom` back to `value`
     assign_value = astx.VariableAssignment(name="value", value=yieldfrom_expr)
@@ -1067,7 +1067,7 @@ def test_transpiler_yieldfromexpr_whilestmt() -> None:
 
     # Generate Python code
     generated_code = translate(while_stmt)
-    expected_code = "while True:\n    value = yield from 1"
+    expected_code = "while True:\n    value = yield from x"
 
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -1053,10 +1053,12 @@ def test_transpiler_yieldfromexpr_whilestmt() -> None:
     while_cond = astx.LiteralBoolean(True)
     while_body = astx.Block()
 
-    # Create the `yield` expression
-    yieldfrom_expr = astx.YieldFromExpr(value=astx.LiteralList([astx.LiteralInt32(1), astx.LiteralInt32(2)]))
+    # Create the `yieldfrom` expression
+    yieldfrom_expr = astx.YieldFromExpr(
+        value=astx.LiteralList([astx.LiteralInt32(1), astx.LiteralInt32(2)])
+    )
 
-    # Assign the result of `yield` back to `value`
+    # Assign the result of `yieldfrom` back to `value`
     assign_value = astx.VariableAssignment(name="value", value=yieldfrom_expr)
 
     # Add the assignment to the loop body


### PR DESCRIPTION
## Pull Request description
This PR adds support for `YieldFrom` expression, extending the previously implemented `Yield` expression with additional testing. It addresses the corresponding [issue](https://github.com/arxlang/astx/issues/200).

<!-- Describe the purpose of your PR and the changes you have made. -->

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #4
-->

## How to test these changes

* run `$ pytest tests/test_callables.py`
* run `$ pytest pytest tests/tools/transpilers/test_python.py`

```python
import astx
from astx.tools.transpilers import python as astx2py
from astx.viz import traverse_ast_ascii, graph_to_ascii

transpiler = astx2py.ASTxPythonTranspiler()

block_ = astx.Block()
block_.append(astx.YieldFromExpr(astx.Variable(name="x")))
block_.append(astx.YieldFromExpr(astx.Variable(name="y")))
block_.append(astx.YieldFromExpr(astx.Variable(name="z")))

generator_proto = astx.FunctionPrototype(
    name="generator",
    args=astx.Arguments(),
    return_type=astx.Int32()
)

generator_main = astx.FunctionDef(prototype=generator_proto, body=block_)
generator_main

yieldfrom_expr = astx.YieldFromExpr(value=astx.Variable(name="x"))
yieldfrom_expr

generator = astx2py.ASTxPythonTranspiler()
generated_code = generator.visit(yieldfrom_expr)
print(generated_code)

generated_code = generator.visit(generator_main)
print(generated_code)

dot_graph = traverse_ast_ascii(generator_main.get_struct(simplified=True))
graph = graph_to_ascii(dot_graph)
print(graph)

dot_graph = traverse_ast_ascii(yieldfrom_expr.get_struct(simplified=True))
graph = graph_to_ascii(dot_graph)
print(graph)
```

Output

```bash
yield from x
```

![ascii1](https://github.com/user-attachments/assets/8c5d2f54-ad74-4d28-af6d-813c841febbe)
![output1](https://github.com/user-attachments/assets/68c44663-d9d9-4190-a106-236c88720ee7)

```bash
def generator() -> int:
    yield from x
    yield from y
    yield from z
```

![ascii2](https://github.com/user-attachments/assets/3ce5cb8c-b538-4755-a291-54f22399ed7f)
![output2](https://github.com/user-attachments/assets/f340a2e8-0612-43ac-a8f3-4a2b7e38693d)

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [x] I managed to reproduce the problem locally from the `main` branch
- [x] I managed to test the new changes locally
- [x] I confirm that the issues mentioned were fixed/resolved .
```
