### PR TITLE
 feat: Add support for `AsyncFor`

### DIFF
--- a/src/astx/__init__.py
+++ b/src/astx/__init__.py
@@ -58,6 +58,8 @@ from astx.exceptions import (
     ThrowStmt,
 )
 from astx.flows import (
+    AsyncForRangeLoopExpr,
+    AsyncForRangeLoopStmt,
     CaseStmt,
     ForCountLoopExpr,
     ForCountLoopStmt,
@@ -199,6 +201,8 @@ __all__ = [
     "Argument",
     "Arguments",
     "AssignmentExpr",
+    "AsyncForRangeLoopExpr",
+    "AsyncForRangeLoopStmt",
     "AwaitExpr",
     "BinaryOp",
     "Block",

--- a/src/astx/base.py
+++ b/src/astx/base.py
@@ -127,6 +127,8 @@ class ASTKind(Enum):
     SwitchStmtKind = -509
     GotoStmtKind = -511
     WithStmtKind = -512
+    AsyncRangeLoopStmtKind = -513
+    AsyncRangeLoopExprKind = -514
 
     # data types
     NullDTKind = -600

--- a/src/astx/flows.py
+++ b/src/astx/flows.py
@@ -345,6 +345,131 @@ class ForCountLoopExpr(Expr):
 
 @public
 @typechecked
+class AsyncForRangeLoopStmt(StatementType):
+    """AST class for asynchronous `For` Range Statement."""
+
+    variable: InlineVariableDeclaration
+    start: Optional[Expr]
+    end: Expr
+    step: Optional[Expr]
+    body: Block
+
+    def __init__(
+        self,
+        variable: InlineVariableDeclaration,
+        start: Optional[Expr],
+        end: Expr,
+        step: Optional[Expr],
+        body: Block,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the AsyncForRangeLoopStmt instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.variable = variable
+        self.start = start
+        self.end = end
+        self.step = step
+        self.body = body
+        self.kind = ASTKind.AsyncRangeLoopStmtKind
+
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        start = self.start
+        end = self.end
+        step = self.step
+        var_name = self.variable.name
+        return f"AsyncForRangeLoopStmt({var_name}=[{start}:{end}:{step}])"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        for_start = {
+            "start": {}
+            if self.start is None
+            else self.start.get_struct(simplified)
+        }
+        for_end = {"end": self.end.get_struct(simplified)}
+        for_step = {
+            "step": {}
+            if self.step is None
+            else self.step.get_struct(simplified)
+        }
+        for_body = self.body.get_struct(simplified)
+
+        key = "ASYNC-FOR-RANGE-LOOP-STMT"
+        value: ReprStruct = {
+            **cast(DictDataTypesStruct, for_start),
+            **cast(DictDataTypesStruct, for_end),
+            **cast(DictDataTypesStruct, for_step),
+            **cast(DictDataTypesStruct, for_body),
+        }
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class AsyncForRangeLoopExpr(Expr):
+    """AST class for asynchronous `For` Range Expression."""
+
+    variable: InlineVariableDeclaration
+    start: Optional[Expr]
+    end: Expr
+    step: Optional[Expr]
+    body: Block
+
+    def __init__(
+        self,
+        variable: InlineVariableDeclaration,
+        start: Optional[Expr],
+        end: Expr,
+        step: Optional[Expr],
+        body: Block,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """Initialize the AsyncForRangeLoopExpr instance."""
+        super().__init__(loc=loc, parent=parent)
+        self.variable = variable
+        self.start = start
+        self.end = end
+        self.step = step
+        self.body = body
+        self.kind = ASTKind.AsyncRangeLoopExprKind
+
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        var_name = self.variable.name
+        return f"AsyncForRangeLoopExpr[{var_name}]"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        for_var = {"var": self.variable.get_struct(simplified)}
+        for_start = {
+            "start": {}
+            if self.start is None
+            else self.start.get_struct(simplified)
+        }
+        for_end = {"end": self.end.get_struct(simplified)}
+        for_step = {
+            "step": {}
+            if self.step is None
+            else self.step.get_struct(simplified)
+        }
+        for_body = self.body.get_struct(simplified)
+
+        key = "ASYNC-FOR-RANGE-LOOP-EXPR"
+        value: ReprStruct = {
+            **cast(DictDataTypesStruct, for_var),
+            **cast(DictDataTypesStruct, for_start),
+            **cast(DictDataTypesStruct, for_end),
+            **cast(DictDataTypesStruct, for_step),
+            **cast(DictDataTypesStruct, for_body),
+        }
+        return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
 class WhileStmt(StatementType):
     """AST class for `while` statement."""
 

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -74,11 +74,21 @@ class ASTxPythonTranspiler:
                 "AsyncForRangeLoopExpr in Python just accept 1 node in the "
                 "body attribute."
             )
+        start = (
+            self.visit(node.start)
+            if getattr(node, "start", None) is not None
+            else "0"
+        )
+        end = self.visit(node.end)
+        step = (
+            self.visit(node.step)
+            if getattr(node, "step", None) is not None
+            else "1"
+        )
+
         return (
             f"result = [{self.visit(node.body).strip()} async for "
-            f"{node.variable.name} in range"
-            f"({self.visit(node.start)}, {self.visit(node.end)}, "
-            f"{self.visit(node.step)})]"
+            f"{node.variable.name} in range({start}, {end}, {step})]"
         )
 
     @dispatch  # type: ignore[no-redef]

--- a/src/astx/tools/transpilers/python.py
+++ b/src/astx/tools/transpilers/python.py
@@ -67,6 +67,21 @@ class ASTxPythonTranspiler:
         return f"{target_str} = {self.visit(node.value)}"
 
     @dispatch  # type: ignore[no-redef]
+    def visit(self, node: astx.AsyncForRangeLoopExpr) -> str:
+        """Handle AsyncForRangeLoopExpr nodes."""
+        if len(node.body) > 1:
+            raise ValueError(
+                "AsyncForRangeLoopExpr in Python just accept 1 node in the "
+                "body attribute."
+            )
+        return (
+            f"result = [{self.visit(node.body).strip()} async for "
+            f"{node.variable.name} in range"
+            f"({self.visit(node.start)}, {self.visit(node.end)}, "
+            f"{self.visit(node.step)})]"
+        )
+
+    @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.AwaitExpr) -> str:
         """Handle AwaitExpr nodes."""
         value = self.visit(node.value) if node.value else ""

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -6,6 +6,8 @@ import pytest
 from astx.base import SourceLocation
 from astx.blocks import Block
 from astx.flows import (
+    AsyncForRangeLoopExpr,
+    AsyncForRangeLoopStmt,
     CaseStmt,
     ForCountLoopExpr,
     ForCountLoopStmt,
@@ -153,6 +155,46 @@ def test_for_count_loop_expr() -> None:
     assert for_expr.get_struct()
     assert for_expr.get_struct(simplified=True)
     visualize(for_expr.get_struct())
+
+
+def test_async_for_range_loop_expr() -> None:
+    """Test `Async For Range Loop` expression`."""
+    decl_a = InlineVariableDeclaration(
+        "a", type_=Int32(), value=LiteralInt32(-1)
+    )
+    start = LiteralInt32(1)
+    end = LiteralInt32(10)
+    step = LiteralInt32(1)
+    body = Block()
+    body.append(LiteralInt32(2))
+    for_expr = AsyncForRangeLoopExpr(
+        variable=decl_a, start=start, end=end, step=step, body=body
+    )
+
+    assert str(for_expr)
+    assert for_expr.get_struct()
+    assert for_expr.get_struct(simplified=True)
+    visualize(for_expr.get_struct())
+
+
+def test_async_for_range_loop_stmt() -> None:
+    """Test `Async For Range Loop` statement."""
+    decl_a = InlineVariableDeclaration(
+        "a", type_=Int32(), value=LiteralInt32(-1)
+    )
+    start = LiteralInt32(1)
+    end = LiteralInt32(10)
+    step = LiteralInt32(1)
+    body = Block()
+    body.append(LiteralInt32(2))
+    for_stmt = AsyncForRangeLoopStmt(
+        variable=decl_a, start=start, end=end, step=step, body=body
+    )
+
+    assert str(for_stmt)
+    assert for_stmt.get_struct()
+    assert for_stmt.get_struct(simplified=True)
+    visualize(for_stmt.get_struct())
 
 
 def test_while_expr() -> None:

--- a/tests/tools/transpilers/test_python.py
+++ b/tests/tools/transpilers/test_python.py
@@ -434,6 +434,29 @@ def test_transpiler_for_range_loop_expr() -> None:
     )
 
 
+def test_transpiler_async_for_range_loop_expr() -> None:
+    """Test `Async For Range Loop` expression`."""
+    decl_a = astx.InlineVariableDeclaration(
+        "a", type_=astx.Int32(), value=astx.LiteralInt32(-1)
+    )
+    start = astx.LiteralInt32(0)
+    end = astx.LiteralInt32(10)
+    step = astx.LiteralInt32(1)
+    body = astx.Block()
+    body.append(astx.LiteralInt32(2))
+
+    for_expr = astx.AsyncForRangeLoopExpr(
+        variable=decl_a, start=start, end=end, step=step, body=body
+    )
+
+    generated_code = translate(for_expr)
+    expected_code = "result = [2 async for a in range(0, 10, 1)]"
+
+    assert generated_code == expected_code, (
+        f"Expected '{expected_code}', but got '{generated_code}'"
+    )
+
+
 def test_transpiler_binary_op() -> None:
     """Test astx.BinaryOp for addition operation."""
     # Create a BinaryOp node for the expression "x + y"


### PR DESCRIPTION
## Pull Request description

<!-- Describe the purpose of your PR and the changes you have made. -->

This PR adds support for `AsyncFor` constructs from the issue https://github.com/arxlang/astx/issues/196.

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #4
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->
run the below code
```
$ pytest tests/test_collections.py
$ pytest pytest tests/tools/transpilers/test_python.py
```

```python
import astx
from astx.tools.transpilers import python as astx2py
from astx.viz import traverse_ast_ascii, graph_to_ascii

transpiler = astx2py.ASTxPythonTranspiler()

block_ = astx.Block()
block_.append(astx.LiteralString("pass"))

var_x = astx.InlineVariableDeclaration(
    "x", type_=astx.Int32(), value=astx.LiteralInt32(-1)
)

var_y = astx.LiteralInt32(5)

asyncfor_expr = astx.AsyncForRangeLoopExpr(
    variable=var_x, start=None, end=var_y, step=None, body=block_
)
asyncfor_expr

generator = astx2py.ASTxPythonTranspiler()
generated_code = generator.visit(asyncfor_expr)
print(generated_code)

dot_graph = traverse_ast_ascii(asyncfor_expr.get_struct(simplified=True))
graph = graph_to_ascii(dot_graph)
print(graph)

```

<!-- Modify the options to suit your project. -->

Output:
```python
result = ['pass' async for x in range(0, 5, 1)]
```
![asyncfor2](https://github.com/user-attachments/assets/fdeb29cf-7f2f-49af-8ad5-3a4610b72255)
![asyncfor1](https://github.com/user-attachments/assets/4b94d0d1-feb3-45db-a3c4-b14c60a9900e)



## Pull Request checklists

Note:

- [x] Share updated images of the graph representation of the new ASTx node
      proposed in this PR, in both image and ASCII formats. For more
      information, check this Google Colab notebook:
      https://colab.research.google.com/drive/1xXwHmOMkJKFSmhRvn4WYfSAsdDzMnawf?usp=sharing

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [x] I managed to reproduce the problem locally from the `main` branch
- [x] I managed to test the new changes locally
- [x] I confirm that the issues mentioned were fixed/resolved .
```
