### PR TITLE
Fix: Update usage demo in README.md and add a test for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ fn_body.append(
         value=astx.BinaryOp(op_code="+", lhs=astx.Variable("x"), rhs=astx.Variable("y"))
     )
 )
-add_function = astx.Function(
-    prototype=astx.FunctionPrototype(name="add", args=args, return_type=astx.Int32),
+add_function = astx.FunctionDef(
+    prototype=astx.FunctionPrototype(name="add", args=args, return_type=astx.Int32()),
     body=fn_body,
 )
 ```
@@ -98,7 +98,7 @@ add_function = astx.Function(
 Use a transpiler to convert the AST to Python code:
 
 ```python
-from astx.transpilers.python import ASTxPythonTranspiler
+from astx_transpilers.python_string import ASTxPythonTranspiler
 
 # Transpile the AST to Python
 transpiler = ASTxPythonTranspiler()

--- a/libs/astx-transpilers/README.md
+++ b/libs/astx-transpilers/README.md
@@ -87,8 +87,8 @@ fn_body.append(
         value=astx.BinaryOp(op_code="+", lhs=astx.Variable("x"), rhs=astx.Variable("y"))
     )
 )
-add_function = astx.Function(
-    prototype=astx.FunctionPrototype(name="add", args=args, return_type=astx.Int32),
+add_function = astx.FunctionDef(
+    prototype=astx.FunctionPrototype(name="add", args=args, return_type=astx.Int32()),
     body=fn_body,
 )
 ```
@@ -98,7 +98,7 @@ add_function = astx.Function(
 Use a transpiler to convert the AST to Python code:
 
 ```python
-from astx.transpilers.python import ASTxPythonTranspiler
+from astx_transpilers.python_string import ASTxPythonTranspiler
 
 # Transpile the AST to Python
 transpiler = ASTxPythonTranspiler()

--- a/libs/astx/README.md
+++ b/libs/astx/README.md
@@ -87,8 +87,8 @@ fn_body.append(
         value=astx.BinaryOp(op_code="+", lhs=astx.Variable("x"), rhs=astx.Variable("y"))
     )
 )
-add_function = astx.Function(
-    prototype=astx.FunctionPrototype(name="add", args=args, return_type=astx.Int32),
+add_function = astx.FunctionDef(
+    prototype=astx.FunctionPrototype(name="add", args=args, return_type=astx.Int32()),
     body=fn_body,
 )
 ```
@@ -98,7 +98,7 @@ add_function = astx.Function(
 Use a transpiler to convert the AST to Python code:
 
 ```python
-from astx.transpilers.python import ASTxPythonTranspiler
+from astx_transpilers.python_string import ASTxPythonTranspiler
 
 # Transpile the AST to Python
 transpiler = ASTxPythonTranspiler()

--- a/libs/astx/tests/test_readme_usage.py
+++ b/libs/astx/tests/test_readme_usage.py
@@ -1,0 +1,46 @@
+"""Test to see if the usage demo in README.md still works."""
+
+import textwrap
+
+
+def usage_demo() -> str:
+    """Execute an exact copy of the code shown in README.md."""
+    import astx
+
+    # Define a simple function `add(x, y): return x + y`
+    args = astx.Arguments(
+        astx.Argument(name="x", type_=astx.Int32()),
+        astx.Argument(name="y", type_=astx.Int32()),
+    )
+    fn_body = astx.Block()
+    fn_body.append(
+        astx.FunctionReturn(
+            value=astx.BinaryOp(
+                op_code="+", lhs=astx.Variable("x"), rhs=astx.Variable("y")
+            )
+        )
+    )
+    add_function = astx.FunctionDef(
+        prototype=astx.FunctionPrototype(
+            name="add", args=args, return_type=astx.Int32()
+        ),
+        body=fn_body,
+    )
+
+    from astx_transpilers.python_string import ASTxPythonTranspiler
+
+    # Transpile the AST to Python
+    transpiler = ASTxPythonTranspiler()
+    python_code = transpiler.visit(add_function)
+
+    return str(python_code)
+
+
+def test_readme_usage() -> None:
+    """Test usage demo as shown in README.md."""
+    expected = """\
+                def add(x: int, y: int) -> int:
+                    return (x + y)
+                """
+
+    assert usage_demo() == textwrap.dedent(expected).strip()


### PR DESCRIPTION
## Pull Request description

<!-- Describe the purpose of your PR and the changes you have made. -->
I updated README.md so the usage demo works
(I already made a pull request for this fix but, after some problem, I tried to refork the project and lost my old pull request)

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #4
-->
README demo was outdated and was no longer working with the current state of the project

## How to test these changes
There is a new test:
libs/astx/tests/test_readme_usage.py
It contains a copy of the code in README.md and assert that the output is valid

<!-- Modify the options to suit your project. -->

## Pull Request checklists

Note:

- [ ] Share updated images of the graph representation of the new ASTx node
      proposed in this PR, in both image and ASCII formats. For more
      information, check this Google Colab notebook:
      https://colab.research.google.com/drive/1xXwHmOMkJKFSmhRvn4WYfSAsdDzMnawf?usp=sharing

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [X] maintenance

About this PR:

- [X] it includes tests.
- [X] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [X] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [X] I have reviewed the changes and it contains no misspelling.
- [X] The code is well commented, especially in the parts that contain more
      complexity.
- [X] New and old tests passed locally.

## Additional information

There is still stuff I do not understand about poetry. 
Forking the repository seems to break the poetry build process on my side and I do not know why.
This time, I recopied manually the .toml and the .lock and it worked!

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
