### PR TITLE
Fix variable name in literal class implementation

### DIFF
--- a/libs/astx/src/astx/literals/base.py
+++ b/libs/astx/src/astx/literals/base.py
@@ -33,8 +33,8 @@ class Literal(DataTypeOps):
 
     def __str__(self) -> str:
         """Return a string that represents the object."""
-        klass = self.__class__.__name__
-        return f"{klass}({self.value})"
+        class_name = self.__class__.__name__
+        return f"{class_name}({self.value})"
 
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST representation for the object."""


### PR DESCRIPTION
## Pull Request description
In the implementation of Literal class in astx.literals.base module, the variable name "klass" is used instead of "class" which creates anonymity in the code for developer and user as well. 
The name is used because **class** is a reserved keyword in python and one can not useit as variable name, but using klass is not a good practice so instead of klass/class class_name can be used.

### Solve #236 

## Pull Request checklists

Note:

- [ ] Share updated images of the graph representation of the new ASTx node
      proposed in this PR, in both image and ASCII formats. For more
      information, check this Google Colab notebook:
      https://colab.research.google.com/drive/1xXwHmOMkJKFSmhRvn4WYfSAsdDzMnawf?usp=sharing

This PR is a:

- [x] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
