### PR TITLE
Add Ellipses

### DIFF
--- a/libs/astx/src/astx/__init__.py
+++ b/libs/astx/src/astx/__init__.py
@@ -13,7 +13,7 @@ from astx import (
     packages,
     symbol_table,
     types,
-    variables,
+    variables,    
 )
 from astx.base import (
     AST,
@@ -134,7 +134,10 @@ from astx.packages import (
     Program,
     Target,
 )
-from astx.subscript import SubscriptExpr
+from astx.subscript import (
+    SubscriptExpr,
+    Ellipsis,
+)
 from astx.types import (
     AndOp,
     BinaryOp,
@@ -320,6 +323,7 @@ __all__ = [
     "StructDeclStmt",
     "StructDefStmt",
     "SubscriptExpr",
+    "Ellipses",
     "SwitchStmt",
     "Target",
     "ThrowStmt",

--- a/libs/astx/src/astx/base.py
+++ b/libs/astx/src/astx/base.py
@@ -184,6 +184,7 @@ class ASTKind(Enum):
 
     # subscrpts
     SubscriptExprKind = -1000
+    EllipsisKind = -1001
 
     # exceptions
     ThrowStmtKind = -1100

--- a/libs/astx/src/astx/subscript.py
+++ b/libs/astx/src/astx/subscript.py
@@ -121,3 +121,44 @@ class SubscriptExpr(Expr):
         value = self._get_struct_wrapper(simplified)
 
         return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class Ellipsis(Expr):
+    """
+    AST class representing the ellipsis (...) syntax in Python.
+    
+    The ellipsis is used in several contexts:
+    1. In slicing: arr[start:stop:...]
+    2. As a placeholder in type hints: Callable[..., ReturnType]
+    3. As a general placeholder in code
+    """
+    
+    def __init__(
+        self,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        """
+        Initialize the Ellipsis instance.
+        
+        Parameters
+        ----------
+        loc: SourceLocation
+            The source location of the expression.
+        parent (optional): ASTNodes
+            The parent AST node.
+        """
+        super().__init__(loc=loc, parent=parent)
+        self.kind = ASTKind.EllipsisKind
+    
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        return "..."
+    
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        key = "Ellipsis"
+        value: DictDataTypesStruct = {}
+        return self._prepare_struct(key, value, simplified)

--- a/libs/astx/tests/test_subscript.py
+++ b/libs/astx/tests/test_subscript.py
@@ -1,7 +1,8 @@
 """Tests for subscripts."""
 
-from astx.literals import LiteralInt32
-from astx.subscript import SubscriptExpr
+from astx.base import ASTKind
+from astx.literals import LiteralInt32, LiteralInteger, LiteralString
+from astx.subscript import Ellipsis, SubscriptExpr
 from astx.variables import Variable
 from astx.viz import visualize
 
@@ -40,3 +41,37 @@ def test_subscriptexpr_index() -> None:
     assert subscr_expr.get_struct()
     assert subscr_expr.get_struct(simplified=True)
     visualize(subscr_expr.get_struct())
+
+def test_ellipsis_init():
+    """Test initialization of Ellipsis."""
+    ellipsis = Ellipsis()
+    assert ellipsis.kind == ASTKind.EllipsisKind
+    assert str(ellipsis) == "..."
+
+
+def test_ellipsis_str():
+    """Test string representation of Ellipsis."""
+    ellipsis = Ellipsis()
+    assert str(ellipsis) == "..."
+
+
+def test_ellipsis_get_struct():
+    """Test get_struct method of Ellipsis."""
+    ellipsis = Ellipsis()
+    struct = ellipsis.get_struct()
+    assert "Ellipsis" in struct
+
+
+def test_ellipsis_in_subscript():
+    """Test Ellipsis used in a subscript context."""
+    arr = LiteralString("arr")
+    start = LiteralInteger(1)
+
+    slice_expr = SubscriptExpr(
+        value=arr,
+        lower=start,
+        upper=Ellipsis(),
+    )
+    
+    assert isinstance(slice_expr.upper, Ellipsis)
+    assert str(slice_expr.upper) == "..."


### PR DESCRIPTION
## Pull Request description


Solve #205

This PR adds the `Ellipsis` class to represent the ellipsis (`...`) syntax in Python. The ellipsis is used in several important contexts:
1. In slicing operations: `arr[start:stop:...]`
2. As a placeholder in type hints: `Callable[..., ReturnType]`
3. As a general placeholder in code

## Changes
- Added `Ellipsis` class in `libs/astx/src/astx/subscript.py`
- Added corresponding tests in `libs/astx/tests/test_subscript.py`
- Added `EllipsisKind` to `ASTKind` enum in `libs/astx/src/astx/base.py`

## How to test these changes

1. Run the test suite with `pytest libs/astx/tests/test_subscript.py::test_ellipsis*`
2. Verify that the `Ellipsis` class can be used in subscript expressions as shown in the tests

## Pull Request checklists

This PR is a:
- [x] new feature

About this PR:
- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:
- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more complexity.
- [x] New and old tests passed locally.
## Additional information
The `Ellipsis` class is implemented as a subclass of `Expr`, following the pattern of other AST nodes in the library. The implementation is minimal as the ellipsis construct doesn't contain any child nodes or additional data.
## Reviewer's checklist

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
