### PR TITLE
Add FormattedValue f-strings

### DIFF
--- a/libs/astx/src/astx/__init__.py
+++ b/libs/astx/src/astx/__init__.py
@@ -107,6 +107,7 @@ from astx.literals import (
     LiteralUInt128,
     LiteralUTF8Char,
     LiteralUTF8String,
+    LiteralFormattedString,
 )
 from astx.mixes import (
     NamedExpr,
@@ -299,6 +300,7 @@ __all__ = [
     "LiteralUInt128",
     "LiteralUTF8Char",
     "LiteralUTF8String",
+    "LiteralFormattedString",
     "Module",
     "MutabilityKind",
     "NamedExpr",

--- a/libs/astx/src/astx/base.py
+++ b/libs/astx/src/astx/base.py
@@ -165,6 +165,7 @@ class ASTKind(Enum):
     TimeDTKind = -624
     DateDTKind = -625
     DateTimeDTKind = -626
+    FormattedStringDTKind = -627
 
     # imports(packages)
     ImportStmtKind = -700


### PR DESCRIPTION
## Pull Request description

This PR adds a new `LiteralFormattedString` class for representing formatted string values (f-strings) in the AST. Instead of using the Python-specific name `FormattedValue`, we've chosen `LiteralFormattedString` to maintain consistency with our existing naming conventions for literal types.

The new class handles all the essential components of formatted strings:
- The expression to be formatted
- Optional format specifiers (e.g., `.2f`)
- Optional conversion flags (`!s`, `!r`, `!a`)

This implementation allows for proper representation of f-string expressions in our AST.

Solves #202 

## How to test these changes

* Run the new unit tests: `pytest tests/datatypes/test_char_string.py -xvs`
* Create a formatted string using the new class and visualize its AST representation

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [x] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.