### PR TITLE
feat: added the support for ellipse

### DIFF
--- a/libs/astx-transpilers/src/astx_transpilers/python_string.py
+++ b/libs/astx-transpilers/src/astx_transpilers/python_string.py
@@ -489,7 +489,9 @@ class ASTxPythonTranspiler:
         value_str = self.visit(node.value)
 
         # Handle Ellipsis in index position
-        if not isinstance(node.index, astx.LiteralNone):
+        if isinstance(node.index, astx.Ellipsis):
+            return f"{value_str}[...]"
+        elif not isinstance(node.index, astx.LiteralNone):
             index_str = self.visit(node.index)
             return f"{value_str}[{index_str}]"
 

--- a/libs/astx-transpilers/tests/test_python.py
+++ b/libs/astx-transpilers/tests/test_python.py
@@ -1783,3 +1783,26 @@ def test_transpiler_set_comprehension_with_multiple_conditions() -> None:
     assert generated_code == expected_code, (
         f"Expected '{expected_code}', but got '{generated_code}'"
     )
+
+
+def test_transpiler_ellipsis() -> None:
+    """Test transpilation of Ellipsis nodes."""
+    ellipsis = astx.Ellipsis()
+
+    generated_code = transpiler.visit(ellipsis)
+    expected_code = "..."
+
+    assert generated_code == expected_code, (
+        f"Expected '{expected_code}', but got '{generated_code}'"
+    )
+
+
+def test_transpiler_ellipsis_in_context() -> None:
+    """Test Ellipsis transpilation within expressions."""
+    ellipsis = astx.Ellipsis()
+    simple_code = transpiler.visit(ellipsis)
+    assert simple_code == "..."
+    var = astx.Variable(name="x")
+    subscr = astx.SubscriptExpr(value=var, index=ellipsis)
+    result = transpiler.visit(subscr)
+    assert "..." in result

--- a/libs/astx/src/astx/__init__.py
+++ b/libs/astx/src/astx/__init__.py
@@ -143,7 +143,10 @@ from astx.packages import (
     Program,
     Target,
 )
-from astx.subscript import SubscriptExpr
+from astx.subscript import (
+    Ellipsis,
+    SubscriptExpr,
+)
 from astx.types import (
     AndOp,
     BinaryOp,
@@ -247,6 +250,7 @@ __all__ = [
     "DictType",
     "DoWhileExpr",
     "DoWhileStmt",
+    "Ellipsis",
     "EnumDeclStmt",
     "ExceptionHandlerStmt",
     "Expr",

--- a/libs/astx/src/astx/base.py
+++ b/libs/astx/src/astx/base.py
@@ -190,6 +190,7 @@ class ASTKind(Enum):
 
     # subscrpts
     SubscriptExprKind = -1000
+    EllipsisKind = -1001
 
     # exceptions
     ThrowStmtKind = -1100

--- a/libs/astx/src/astx/subscript.py
+++ b/libs/astx/src/astx/subscript.py
@@ -136,12 +136,8 @@ class Ellipsis(Expr):
         super().__init__(loc=loc, parent=parent)
         self.kind = ASTKind.EllipsisKind
 
-    def __str__(self) -> str:
-        """Return a string that represents the object."""
-        return "..."
-
     def get_struct(self, simplified: bool = False) -> ReprStruct:
         """Return the AST structure of the object."""
-        key = "Ellipsis"
+        key = str(self)
         value: DictDataTypesStruct = {}
         return self._prepare_struct(key, value, simplified)

--- a/libs/astx/src/astx/subscript.py
+++ b/libs/astx/src/astx/subscript.py
@@ -121,3 +121,27 @@ class SubscriptExpr(Expr):
         value = self._get_struct_wrapper(simplified)
 
         return self._prepare_struct(key, value, simplified)
+
+
+@public
+@typechecked
+class Ellipsis(Expr):
+    """AST class for Ellipsis expressions."""
+
+    def __init__(
+        self,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        super().__init__(loc=loc, parent=parent)
+        self.kind = ASTKind.EllipsisKind
+
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        return "..."
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure of the object."""
+        key = "Ellipsis"
+        value: DictDataTypesStruct = {}
+        return self._prepare_struct(key, value, simplified)

--- a/libs/astx/tests/test_subscript.py
+++ b/libs/astx/tests/test_subscript.py
@@ -65,7 +65,7 @@ def test_ellipsis_in_various_slice_positions() -> None:
         upper=Ellipsis(),
     )
     assert isinstance(slice_upper.upper, Ellipsis)
-    assert str(slice_upper).find("...") > 0
+    assert "Ellipsis" in str(slice_upper)  # Changed from "..." to "Ellipsis"
     # Case 2:lower bound
     slice_lower = SubscriptExpr(
         value=arr,
@@ -108,5 +108,5 @@ def test_ellipsis_nested_expressions() -> None:
         value=inner_arr,
         index=Ellipsis(),
     )
-    assert str(inner_subscr).find("...") > 0
+    assert "Ellipsis" in str(inner_subscr)
     assert isinstance(inner_subscr.index, Ellipsis)

--- a/libs/astx/tests/test_subscript.py
+++ b/libs/astx/tests/test_subscript.py
@@ -49,7 +49,7 @@ def test_ellipsis_basic_properties() -> None:
     """Test basic properties of the Ellipsis class."""
     ellip = Ellipsis()
     assert ellip.kind == ASTKind.EllipsisKind
-    assert str(ellip) == "..."
+    assert str(ellip) == "Ellipsis"
     struct = ellip.get_struct()
     struct_dict = cast(DictDataTypesStruct, struct)
     assert "Ellipsis" in struct_dict

--- a/libs/astx/tests/test_subscript.py
+++ b/libs/astx/tests/test_subscript.py
@@ -1,7 +1,10 @@
 """Tests for subscripts."""
 
+from typing import cast
+
+from astx.base import ASTKind, DictDataTypesStruct
 from astx.literals import LiteralInt32
-from astx.subscript import SubscriptExpr
+from astx.subscript import Ellipsis, SubscriptExpr
 from astx.variables import Variable
 from astx.viz import visualize
 
@@ -40,3 +43,70 @@ def test_subscriptexpr_index() -> None:
     assert subscr_expr.get_struct()
     assert subscr_expr.get_struct(simplified=True)
     visualize(subscr_expr.get_struct())
+
+
+def test_ellipsis_basic_properties() -> None:
+    """Test basic properties of the Ellipsis class."""
+    ellip = Ellipsis()
+    assert ellip.kind == ASTKind.EllipsisKind
+    assert str(ellip) == "..."
+    struct = ellip.get_struct()
+    struct_dict = cast(DictDataTypesStruct, struct)
+    assert "Ellipsis" in struct_dict
+
+
+def test_ellipsis_in_various_slice_positions() -> None:
+    """Test Ellipsis used in different positions in subscript expressions."""
+    arr = Variable(name="array")
+    # Case 1:upper bound
+    slice_upper = SubscriptExpr(
+        value=arr,
+        lower=LiteralInt32(1),
+        upper=Ellipsis(),
+    )
+    assert isinstance(slice_upper.upper, Ellipsis)
+    assert str(slice_upper).find("...") > 0
+    # Case 2:lower bound
+    slice_lower = SubscriptExpr(
+        value=arr,
+        lower=Ellipsis(),
+        upper=LiteralInt32(10),
+    )
+    assert isinstance(slice_lower.lower, Ellipsis)
+    # Case 3:ellipse as an step
+    slice_step = SubscriptExpr(
+        value=arr,
+        lower=LiteralInt32(1),
+        upper=LiteralInt32(10),
+        step=Ellipsis(),
+    )
+    assert isinstance(slice_step.step, Ellipsis)
+
+
+def test_ellipsis_as_standalone_index() -> None:
+    """Test using Ellipsis as a standalone index - array[...]."""
+    arr = Variable(name="data")
+    subscr = SubscriptExpr(
+        value=arr,
+        index=Ellipsis(),
+    )
+
+    assert isinstance(subscr.index, Ellipsis)
+    struct = subscr.get_struct()
+    struct_dict = cast(DictDataTypesStruct, struct)
+    assert "SubscriptExpr" in struct_dict
+    subscr_dict = cast(DictDataTypesStruct, struct_dict["SubscriptExpr"])
+    content_dict = cast(DictDataTypesStruct, subscr_dict["content"])
+    assert "indexed" in content_dict
+    assert "index" in content_dict
+
+
+def test_ellipsis_nested_expressions() -> None:
+    """Test Ellipsis in more complex nested expressions."""
+    inner_arr = Variable(name="vector")
+    inner_subscr = SubscriptExpr(
+        value=inner_arr,
+        index=Ellipsis(),
+    )
+    assert str(inner_subscr).find("...") > 0
+    assert isinstance(inner_subscr.index, Ellipsis)


### PR DESCRIPTION
## Pull Request description

Added Ellipsis AST node support for handling Python's ... syntax in slicing and type hints.

 Which issue this PR aims to resolve  #205 


## How to test these changes

`pytest libs\astx-transpilers\tests\test_python.py -v `
`pytest libs\astx\tests\test_subscript.py -v `

## Pull Request checklists

Note:

- [ ] Share updated images of the graph representation of the new ASTx node
      proposed in this PR, in both image and ASCII formats. For more
      information, check this Google Colab notebook:
      https://colab.research.google.com/drive/1xXwHmOMkJKFSmhRvn4WYfSAsdDzMnawf?usp=sharing


![image](https://github.com/user-attachments/assets/e6346e74-d6e4-48c8-a46a-9357ee5660e7)
![image](https://github.com/user-attachments/assets/a210d9ca-2309-4cc4-a899-26839546b8eb)

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
