### PR TITLE
feat: add Starred operator implementation with tests

### DIFF
--- a/libs/astx-transpilers/src/astx_transpilers/python_string.py
+++ b/libs/astx-transpilers/src/astx_transpilers/python_string.py
@@ -3,8 +3,8 @@
 from typing import Union, cast
 
 import astx
-import astx.operators
 
+from astx.operators import Starred
 from astx.tools.typing import typechecked
 from plum import dispatch
 
@@ -482,6 +482,12 @@ class ASTxPythonTranspiler:
         """Handle StructDeclStmt and StructDefStmt nodes."""
         attrs_str = "\n    ".join(self.visit(attr) for attr in node.attributes)
         return f"@dataclass \nclass {node.name}:\n    {attrs_str}"
+
+    @dispatch  # type: ignore[no-redef]
+    def visit(self, node: Starred) -> str:
+        """Handle Starred nodes."""
+        value = self.visit(node.value)
+        return f"*{value}"
 
     @dispatch  # type: ignore[no-redef]
     def visit(self, node: astx.SubscriptExpr) -> str:

--- a/libs/astx-transpilers/tests/test_python.py
+++ b/libs/astx-transpilers/tests/test_python.py
@@ -1806,3 +1806,40 @@ def test_transpiler_ellipsis_in_context() -> None:
     subscr = astx.SubscriptExpr(value=var, index=ellipsis)
     result = transpiler.visit(subscr)
     assert "..." in result
+
+
+def test_transpiler_starred_simple() -> None:
+    """Test simple starred expression transpilation."""
+    var = astx.Variable(name="args")
+    starred = astx.Starred(value=var)
+    generated_code = translate(starred)
+    expected_code = "*args"
+    assert generated_code == expected_code
+
+
+def test_transpiler_starred_in_list() -> None:
+    """Test starred expression within a list literal transpilation."""
+    var = astx.Variable(name="items")
+    starred = astx.Starred(value=var)
+    lit_1 = astx.LiteralInt32(1)
+    lit_2 = astx.LiteralInt32(2)
+    starred_code = translate(starred)
+    assert starred_code == "*items"
+    expected_code = "[1, *items, 2]"
+    manual_result = f"[{translate(lit_1)}, {starred_code}, {translate(lit_2)}]"
+    assert manual_result == expected_code
+
+
+def test_transpiler_multiple_starred() -> None:
+    """Test multiple starred expressions transpilation."""
+    var1 = astx.Variable(name="args1")
+    var2 = astx.Variable(name="args2")
+    starred1 = astx.Starred(value=var1)
+    starred2 = astx.Starred(value=var2)
+    code1 = translate(starred1)
+    code2 = translate(starred2)
+    assert code1 == "*args1"
+    assert code2 == "*args2"
+    expected_code = "[*args1, *args2]"
+    manual_result = f"[{code1}, {code2}]"
+    assert manual_result == expected_code

--- a/libs/astx/src/astx/__init__.py
+++ b/libs/astx/src/astx/__init__.py
@@ -129,6 +129,7 @@ from astx.operators import (
     AssignmentExpr,
     AugAssign,
     CompareOp,
+    Starred,
     VariableAssignment,
     WalrusOp,
 )
@@ -334,6 +335,7 @@ __all__ = [
     "SetType",
     "SignedInteger",
     "SourceLocation",
+    "Starred",
     "StatementType",
     "String",
     "StructDeclStmt",

--- a/libs/astx/src/astx/base.py
+++ b/libs/astx/src/astx/base.py
@@ -106,6 +106,7 @@ class ASTKind(Enum):
     AssignmentExprKind = -303
     AugmentedAssignKind = -304
     CompareOpKind = -305
+    StarredKind = -306
 
     # functions
     PrototypeKind = -400

--- a/libs/astx/src/astx/operators.py
+++ b/libs/astx/src/astx/operators.py
@@ -226,3 +226,31 @@ class CompareOp(DataType):
             ],
         }
         return self._prepare_struct(key, content, simplified)
+
+
+@public
+@typechecked
+class Starred(Expr):
+    """AST class for starred expressions (*expr)."""
+
+    value: Expr
+
+    def __init__(
+        self,
+        value: Expr,
+        loc: SourceLocation = NO_SOURCE_LOCATION,
+        parent: Optional[ASTNodes] = None,
+    ) -> None:
+        super().__init__(loc=loc, parent=parent)
+        self.value = value
+        self.kind = ASTKind.StarredKind
+
+    def __str__(self) -> str:
+        """Return a string that represents the object."""
+        return f"Starred[*]({self.value})"
+
+    def get_struct(self, simplified: bool = False) -> ReprStruct:
+        """Return the AST structure that represents the object."""
+        key = "STARRED[*]"
+        content: ReprStruct = {"value": self.value.get_struct(simplified)}
+        return self._prepare_struct(key, content, simplified)

--- a/libs/astx/tests/test_operators.py
+++ b/libs/astx/tests/test_operators.py
@@ -5,6 +5,7 @@ from typing import cast
 import astx
 import pytest
 
+from astx.base import ASTKind, Identifier
 from astx.literals.numeric import LiteralInt32
 from astx.operators import (
     AssignmentExpr,
@@ -152,3 +153,39 @@ def test_aug_assign_operations(operator: OpCodeAugAssign, value: int) -> None:
     assert str(aug_assign) == f"AugAssign[{operator}]"
     assert aug_assign.get_struct()
     assert aug_assign.get_struct(simplified=True)
+
+
+def test_starred_creation() -> None:
+    """Test creating a Starred operator."""
+    var = astx.Variable(name="args")
+    starred = astx.Starred(value=var)
+    assert starred.value == var
+    assert starred.kind == ASTKind.StarredKind
+    assert str(starred) == "Starred[*](Variable[args])"
+
+    # Test structure
+    struct = starred.get_struct()
+    assert struct is not None
+    simplified_struct = starred.get_struct(simplified=True)
+    assert simplified_struct is not None
+
+
+def test_starred_with_different_expressions() -> None:
+    """Test Starred with different types of expressions."""
+    # Test with Identifier
+    ident = Identifier("a")
+    starred_ident = astx.Starred(value=ident)
+    assert starred_ident.kind == ASTKind.StarredKind
+    assert starred_ident.get_struct() is not None
+
+    # Test with Literal
+    lit = LiteralInt32(42)
+    starred_lit = astx.Starred(value=lit)
+    assert str(starred_lit) == "Starred[*](LiteralInt32(42))"
+    assert starred_lit.get_struct() is not None
+
+    # Test with Variable
+    var = Variable(name="x")
+    starred_var = astx.Starred(value=var)
+    assert str(starred_var) == "Starred[*](Variable[x])"
+    assert starred_var.get_struct() is not None


### PR DESCRIPTION
## Pull Request description
This pull request introduces support for the Starred operator in the ASTX transpiler. The Starred operator is used to represent unpacking operations (e.g., *args) in Python's abstract syntax tree (AST).

-Solve #203 

## How to test these changes

- run 
- `pytest  libs\astx\tests\test_operators.py  -v`
- `pytest libs\astx-transpilers\tests\test_python.py -v  `


## Pull Request checklists

Note:

- [x] Share updated images of the graph representation of the new ASTx node
      proposed in this PR, in both image and ASCII formats. For more
      information, check this Google Colab notebook:
      https://colab.research.google.com/drive/1xXwHmOMkJKFSmhRvn4WYfSAsdDzMnawf?usp=sharing

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->
![image](https://github.com/user-attachments/assets/2f105138-076c-4414-84a1-90e69726c16b)
![image](https://github.com/user-attachments/assets/9c2df678-b22a-4bd0-8f30-d9c928a097af)


<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
